### PR TITLE
Remove placeholder main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,9 +1,0 @@
-package main
-
-import (
-	_ "github.com/hashicorp/terraform-plugin-framework/attr"
-)
-
-// TODO: Remove file when validator packages are implemented.
-func main() {
-}


### PR DESCRIPTION
This file was there to bootstrap the Go module, but serves no actual purpose.