### PR TITLE
all: Add package level Go documentation and fix int64validator package naming in source files

### DIFF
--- a/float64validator/doc.go
+++ b/float64validator/doc.go
@@ -1,0 +1,2 @@
+// Package float64validator provides validators for types.Float64 attributes.
+package float64validator

--- a/int64validator/at_least.go
+++ b/int64validator/at_least.go
@@ -1,4 +1,4 @@
-package validate
+package int64validator
 
 import (
 	"context"

--- a/int64validator/at_least_test.go
+++ b/int64validator/at_least_test.go
@@ -1,4 +1,4 @@
-package validate
+package int64validator
 
 import (
 	"context"

--- a/int64validator/at_most.go
+++ b/int64validator/at_most.go
@@ -1,4 +1,4 @@
-package validate
+package int64validator
 
 import (
 	"context"

--- a/int64validator/at_most_test.go
+++ b/int64validator/at_most_test.go
@@ -1,4 +1,4 @@
-package validate
+package int64validator
 
 import (
 	"context"

--- a/int64validator/between.go
+++ b/int64validator/between.go
@@ -1,4 +1,4 @@
-package validate
+package int64validator
 
 import (
 	"context"

--- a/int64validator/between_test.go
+++ b/int64validator/between_test.go
@@ -1,4 +1,4 @@
-package validate
+package int64validator
 
 import (
 	"context"

--- a/int64validator/doc.go
+++ b/int64validator/doc.go
@@ -1,0 +1,2 @@
+// Package int64validator provides validators for types.Int64 attributes.
+package int64validator

--- a/stringvalidator/doc.go
+++ b/stringvalidator/doc.go
@@ -1,0 +1,2 @@
+// Package stringvalidator provides validators for types.String attributes.
+package stringvalidator

--- a/validatordiag/doc.go
+++ b/validatordiag/doc.go
@@ -1,0 +1,3 @@
+// Package validatordiag provides diagnostics helpers for validator
+// implementations.
+package validatordiag


### PR DESCRIPTION
Reference: https://pkg.go.dev/github.com/hashicorp/terraform-plugin-framework-validators

This will improve the usability of browsing the Go documentation.