### PR TITLE
Adding `AtLeastSumOf`, `AtMostSumOf`, `EqualToSumOf` Validators

### DIFF
--- a/.changelog/29.txt
+++ b/.changelog/29.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+int64validator: New validators `AtLeastSumOf`, `AtMostSumOf` and `EqualToSumOf`, that compare value of an attribute, against the sum of the value of other attributes
+```

--- a/.changelog/29.txt
+++ b/.changelog/29.txt
@@ -1,3 +1,3 @@
-```release-note:feature
-int64validator: New validators `AtLeastSumOf`, `AtMostSumOf` and `EqualToSumOf`, that compare value of an attribute, against the sum of the value of other attributes
+```release-note:enhancement
+int64validator: Added `AtLeastSumOf()`, `AtMostSumOf()` and `EqualToSumOf()` validation functions
 ```

--- a/go.mod
+++ b/go.mod
@@ -4,22 +4,22 @@ go 1.17
 
 require (
 	github.com/google/go-cmp v0.5.8
-	github.com/hashicorp/terraform-plugin-framework v0.9.1-0.20220711170800-89baaa204707
-	github.com/hashicorp/terraform-plugin-go v0.11.0
+	github.com/hashicorp/terraform-plugin-framework v0.10.0
+	github.com/hashicorp/terraform-plugin-go v0.12.0
 )
 
 require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.2.1 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.4.1 // indirect
+	github.com/hashicorp/terraform-plugin-log v0.6.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect
-	github.com/vmihailenco/tagparser v0.1.1 // indirect
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
-	google.golang.org/appengine v1.6.5 // indirect
+	github.com/vmihailenco/tagparser v0.1.2 // indirect
+	golang.org/x/net v0.0.0-20220708220712-1185a9018129 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -62,12 +62,12 @@ github.com/hashicorp/go-hclog v1.2.1/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVH
 github.com/hashicorp/go-plugin v1.4.4/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/terraform-plugin-framework v0.9.1-0.20220711170800-89baaa204707 h1:4wAdubsgZ/eAbCjW2At8w6UDeVCel76jWDHsWvbc8Pk=
-github.com/hashicorp/terraform-plugin-framework v0.9.1-0.20220711170800-89baaa204707/go.mod h1:+H4ieVu7X4bfYlLB/zytek48e4CjcG+gjKdVOjVY1PU=
-github.com/hashicorp/terraform-plugin-go v0.11.0 h1:YXsvSCx7GbQO5jIUQd77FesqmIBxgSvYAtAX1NqErTk=
-github.com/hashicorp/terraform-plugin-go v0.11.0/go.mod h1:aphXBG8qtQH0yF1waMRlaw/3G+ZFlR/6Artnvt1QEDE=
-github.com/hashicorp/terraform-plugin-log v0.4.1 h1:xpbmVhvuU3mgHzLetOmx9pkOL2rmgpu302XxddON6eo=
-github.com/hashicorp/terraform-plugin-log v0.4.1/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
+github.com/hashicorp/terraform-plugin-framework v0.10.0 h1:LGYcnvNdVaZA1ZHe53BHLVjaaGs7HTiq6+9Js29stL4=
+github.com/hashicorp/terraform-plugin-framework v0.10.0/go.mod h1:CK7Opzukfu/2CPJs+HzUdfHrFlp+ZIQeSxjF0x8k464=
+github.com/hashicorp/terraform-plugin-go v0.12.0 h1:6wW9mT1dSs0Xq4LR6HXj1heQ5ovr5GxXNJwkErZzpJw=
+github.com/hashicorp/terraform-plugin-go v0.12.0/go.mod h1:kwhmaWHNDvT1B3QiSJdAtrB/D4RaKSY/v3r2BuoWK4M=
+github.com/hashicorp/terraform-plugin-log v0.6.0 h1:/Vq78uSIdUSZ3iqDc9PESKtwt8YqNKN6u+khD+lLjuw=
+github.com/hashicorp/terraform-plugin-log v0.6.0/go.mod h1:p4R1jWBXRTvL4odmEkFfDdhUjHf9zcs/BCoNHAc7IK4=
 github.com/hashicorp/terraform-registry-address v0.0.0-20220623143253-7d51757b572c/go.mod h1:Wn3Na71knbXc1G8Lh+yu/dQWWJeFQEpDeJMtWMtlmNI=
 github.com/hashicorp/terraform-svchost v0.0.0-20200729002733-f050f53b9734/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
@@ -110,6 +110,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
+github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
+github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -134,6 +136,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220708220712-1185a9018129 h1:vucSRfWwTsoXro7P+3Cjlr6flUMtzCwzlvkxEQtHHB0=
+golang.org/x/net v0.0.0-20220708220712-1185a9018129/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -157,6 +161,8 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 h1:nonptSpoQ4vQjyraW20DXPAglgQfVnM9ZC6MmNLMR60=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -174,6 +180,8 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
+google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20170818010345-ee236bd376b0/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
@@ -187,7 +195,7 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0/go.mod h1:DNq5QpG7LJqD2AamLZ7zvKE0DEpVl2BSEVjFycAAjRY=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/int64validator/at_least_sum_of.go
+++ b/int64validator/at_least_sum_of.go
@@ -21,9 +21,9 @@ type atLeastSumOfValidator struct {
 }
 
 // Description describes the validation in plain text formatting.
-func (validator atLeastSumOfValidator) Description(_ context.Context) string {
+func (av atLeastSumOfValidator) Description(_ context.Context) string {
 	var attributePaths []string
-	for _, p := range validator.attributesToSumPathExpressions {
+	for _, p := range av.attributesToSumPathExpressions {
 		attributePaths = append(attributePaths, p.String())
 	}
 
@@ -31,22 +31,23 @@ func (validator atLeastSumOfValidator) Description(_ context.Context) string {
 }
 
 // MarkdownDescription describes the validation in Markdown formatting.
-func (validator atLeastSumOfValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
+func (av atLeastSumOfValidator) MarkdownDescription(ctx context.Context) string {
+	return av.Description(ctx)
 }
 
 // Validate performs the validation.
-func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
+func (av atLeastSumOfValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
 	i, ok := validateInt(ctx, request, response)
-
 	if !ok {
 		return
 	}
 
-	var sumOfAttribs int64
-	var numUnknownAttribsToSum int
+	// Ensure input path expressions resolution against the current attribute
+	expressions := request.AttributePathExpression.MergeExpressions(av.attributesToSumPathExpressions...)
 
-	for _, expression := range validator.attributesToSumPathExpressions {
+	// Sum the value of all the attributes involved, but only if they are all known.
+	var sumOfAttribs int64
+	for _, expression := range expressions {
 		matchedPaths, diags := request.Config.PathMatches(ctx, expression)
 		response.Diagnostics.Append(diags...)
 
@@ -56,8 +57,13 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 		}
 
 		for _, mp := range matchedPaths {
-			var attribToSum types.Int64
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(request.AttributePath) {
+				continue
+			}
 
+			var attribToSum types.Int64
 			diags := request.Config.GetAttribute(ctx, mp, &attribToSum)
 			response.Diagnostics.Append(diags...)
 
@@ -66,12 +72,13 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 				continue
 			}
 
-			if attribToSum.IsNull() {
-				continue
+			// Delay validation until all involved attribute have a known value
+			if attribToSum.IsUnknown() {
+				return
 			}
 
-			if attribToSum.IsUnknown() {
-				numUnknownAttribsToSum++
+			// Attribute is null, so it doesn't contribute to the sum
+			if attribToSum.IsNull() {
 				continue
 			}
 
@@ -79,14 +86,10 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 		}
 	}
 
-	if numUnknownAttribsToSum > 0 {
-		return
-	}
-
 	if i < sumOfAttribs {
 		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.AttributePath,
-			validator.Description(ctx),
+			av.Description(ctx),
 			fmt.Sprintf("%d", i),
 		))
 

--- a/int64validator/at_least_sum_of.go
+++ b/int64validator/at_least_sum_of.go
@@ -44,6 +44,7 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 	}
 
 	var sumOfAttribs int64
+	var numUnknownAttribsToSum int
 
 	for _, path := range validator.attributesToSumPaths {
 		var attribToSum types.Int64
@@ -53,7 +54,20 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 			return
 		}
 
+		if attribToSum.Null {
+			continue
+		}
+
+		if attribToSum.Unknown {
+			numUnknownAttribsToSum++
+			continue
+		}
+
 		sumOfAttribs += attribToSum.Value
+	}
+
+	if numUnknownAttribsToSum == len(validator.attributesToSumPaths) {
+		return
 	}
 
 	if i < sumOfAttribs {
@@ -75,7 +89,7 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 //     - Is exclusively at least the sum of the given attributes.
 //
 // Null (unconfigured) and unknown (known after apply) values are skipped.
-func AtLeastSumOf(attributesToSum []*tftypes.AttributePath) tfsdk.AttributeValidator {
+func AtLeastSumOf(attributesToSum ...*tftypes.AttributePath) tfsdk.AttributeValidator {
 	return atLeastSumOfValidator{
 		attributesToSumPaths: attributesToSum,
 	}

--- a/int64validator/at_least_sum_of.go
+++ b/int64validator/at_least_sum_of.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 )
 
 var _ tfsdk.AttributeValidator = atLeastSumOfValidator{}
@@ -17,14 +17,14 @@ var _ tfsdk.AttributeValidator = atLeastSumOfValidator{}
 // atLeastSumOfValidator validates that an integer Attribute's value is at least the sum of one
 // or more integer Attributes.
 type atLeastSumOfValidator struct {
-	attributesToSumPaths []*tftypes.AttributePath
+	attributesToSumPaths []path.Path
 }
 
 // Description describes the validation in plain text formatting.
 func (validator atLeastSumOfValidator) Description(_ context.Context) string {
 	var attributePaths []string
-	for _, path := range validator.attributesToSumPaths {
-		attributePaths = append(attributePaths, path.String())
+	for _, p := range validator.attributesToSumPaths {
+		attributePaths = append(attributePaths, p.String())
 	}
 
 	return fmt.Sprintf("value must be at least sum of %s", strings.Join(attributePaths, " + "))
@@ -46,10 +46,10 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 	var sumOfAttribs int64
 	var numUnknownAttribsToSum int
 
-	for _, path := range validator.attributesToSumPaths {
+	for _, p := range validator.attributesToSumPaths {
 		var attribToSum types.Int64
 
-		response.Diagnostics.Append(request.Config.GetAttribute(ctx, path, &attribToSum)...)
+		response.Diagnostics.Append(request.Config.GetAttribute(ctx, p, &attribToSum)...)
 		if response.Diagnostics.HasError() {
 			return
 		}
@@ -72,7 +72,7 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 
 	if i < sumOfAttribs {
 
-		response.Diagnostics.Append(validatordiag.AttributeValueDiagnostic(
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.AttributePath,
 			validator.Description(ctx),
 			fmt.Sprintf("%d", i),
@@ -89,7 +89,7 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 //     - Is exclusively at least the sum of the given attributes.
 //
 // Null (unconfigured) and unknown (known after apply) values are skipped.
-func AtLeastSumOf(attributesToSum ...*tftypes.AttributePath) tfsdk.AttributeValidator {
+func AtLeastSumOf(attributesToSum ...path.Path) tfsdk.AttributeValidator {
 	return atLeastSumOfValidator{
 		attributesToSumPaths: attributesToSum,
 	}

--- a/int64validator/at_least_sum_of.go
+++ b/int64validator/at_least_sum_of.go
@@ -79,7 +79,7 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 		}
 	}
 
-	if numUnknownAttribsToSum == len(validator.attributesToSumPathExpressions) {
+	if numUnknownAttribsToSum > 0 {
 		return
 	}
 

--- a/int64validator/at_least_sum_of.go
+++ b/int64validator/at_least_sum_of.go
@@ -15,15 +15,15 @@ import (
 var _ tfsdk.AttributeValidator = atLeastSumOfValidator{}
 
 // atLeastSumOfValidator validates that an integer Attribute's value is at least the sum of one
-// or more integer Attributes.
+// or more integer Attributes retrieved via the given path expressions.
 type atLeastSumOfValidator struct {
-	attributesToSumPaths []path.Path
+	attributesToSumPathExpressions path.Expressions
 }
 
 // Description describes the validation in plain text formatting.
 func (validator atLeastSumOfValidator) Description(_ context.Context) string {
 	var attributePaths []string
-	for _, p := range validator.attributesToSumPaths {
+	for _, p := range validator.attributesToSumPathExpressions {
 		attributePaths = append(attributePaths, p.String())
 	}
 
@@ -46,32 +46,44 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 	var sumOfAttribs int64
 	var numUnknownAttribsToSum int
 
-	for _, p := range validator.attributesToSumPaths {
-		var attribToSum types.Int64
+	for _, expression := range validator.attributesToSumPathExpressions {
+		matchedPaths, diags := request.Config.PathMatches(ctx, expression)
+		response.Diagnostics.Append(diags...)
 
-		response.Diagnostics.Append(request.Config.GetAttribute(ctx, p, &attribToSum)...)
-		if response.Diagnostics.HasError() {
-			return
-		}
-
-		if attribToSum.Null {
+		// Collect all errors
+		if diags.HasError() {
 			continue
 		}
 
-		if attribToSum.Unknown {
-			numUnknownAttribsToSum++
-			continue
-		}
+		for _, mp := range matchedPaths {
+			var attribToSum types.Int64
 
-		sumOfAttribs += attribToSum.Value
+			diags := request.Config.GetAttribute(ctx, mp, &attribToSum)
+			response.Diagnostics.Append(diags...)
+
+			// Collect all errors
+			if diags.HasError() {
+				continue
+			}
+
+			if attribToSum.IsNull() {
+				continue
+			}
+
+			if attribToSum.IsUnknown() {
+				numUnknownAttribsToSum++
+				continue
+			}
+
+			sumOfAttribs += attribToSum.Value
+		}
 	}
 
-	if numUnknownAttribsToSum == len(validator.attributesToSumPaths) {
+	if numUnknownAttribsToSum == len(validator.attributesToSumPathExpressions) {
 		return
 	}
 
 	if i < sumOfAttribs {
-
 		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.AttributePath,
 			validator.Description(ctx),
@@ -86,11 +98,9 @@ func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfs
 // attribute value:
 //
 //     - Is a number, which can be represented by a 64-bit integer.
-//     - Is exclusively at least the sum of the given attributes.
+//     - Is at least the sum of the attributes retrieved via the given path expression(s).
 //
 // Null (unconfigured) and unknown (known after apply) values are skipped.
-func AtLeastSumOf(attributesToSum ...path.Path) tfsdk.AttributeValidator {
-	return atLeastSumOfValidator{
-		attributesToSumPaths: attributesToSum,
-	}
+func AtLeastSumOf(attributesToSumPathExpressions ...path.Expression) tfsdk.AttributeValidator {
+	return atLeastSumOfValidator{attributesToSumPathExpressions}
 }

--- a/int64validator/at_least_sum_of.go
+++ b/int64validator/at_least_sum_of.go
@@ -1,0 +1,82 @@
+package int64validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/validatordiag"
+)
+
+var _ tfsdk.AttributeValidator = atLeastSumOfValidator{}
+
+// atLeastSumOfValidator validates that an integer Attribute's value is at least the sum of one
+// or more integer Attributes.
+type atLeastSumOfValidator struct {
+	attributesToSumPaths []*tftypes.AttributePath
+}
+
+// Description describes the validation in plain text formatting.
+func (validator atLeastSumOfValidator) Description(_ context.Context) string {
+	var attributePaths []string
+	for _, path := range validator.attributesToSumPaths {
+		attributePaths = append(attributePaths, path.String())
+	}
+
+	return fmt.Sprintf("value must be at least sum of %s", strings.Join(attributePaths, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator atLeastSumOfValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator atLeastSumOfValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
+	i, ok := validateInt(ctx, request, response)
+
+	if !ok {
+		return
+	}
+
+	var sumOfAttribs int64
+
+	for _, path := range validator.attributesToSumPaths {
+		var attribToSum types.Int64
+
+		response.Diagnostics.Append(request.Config.GetAttribute(ctx, path, &attribToSum)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		sumOfAttribs += attribToSum.Value
+	}
+
+	if i < sumOfAttribs {
+
+		response.Diagnostics.Append(validatordiag.AttributeValueDiagnostic(
+			request.AttributePath,
+			validator.Description(ctx),
+			fmt.Sprintf("%d", i),
+		))
+
+		return
+	}
+}
+
+// AtLeastSumOf returns an AttributeValidator which ensures that any configured
+// attribute value:
+//
+//     - Is a number, which can be represented by a 64-bit integer.
+//     - Is exclusively at least the sum of the given attributes.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AtLeastSumOf(attributesToSum []*tftypes.AttributePath) tfsdk.AttributeValidator {
+	return atLeastSumOfValidator{
+		attributesToSumPaths: attributesToSum,
+	}
+}

--- a/int64validator/at_least_sum_of_test.go
+++ b/int64validator/at_least_sum_of_test.go
@@ -86,6 +86,18 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 				"two": tftypes.NewValue(tftypes.Number, nil),
 			},
 		},
+		"valid integer as Int64 returns error when all attributes to sum are null": {
+			val: types.Int64{Value: -1},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, nil),
+			},
+			expectError: true,
+		},
 		"valid integer as Int64 greater than sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 10},
 			attributesToSumPaths: []*tftypes.AttributePath{
@@ -107,6 +119,29 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 			},
+		},
+		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
+			val: types.Int64{Value: -1},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+		"error when attribute to sum is not Number": {
+			val: types.Int64{Value: 9},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Bool, true),
+				"two": tftypes.NewValue(tftypes.Number, 9),
+			},
+			expectError: true,
 		},
 	}
 
@@ -130,7 +165,7 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 
 			response := tfsdk.ValidateAttributeResponse{}
 
-			AtLeastSumOf(test.attributesToSumPaths).Validate(context.Background(), request, &response)
+			AtLeastSumOf(test.attributesToSumPaths...).Validate(context.Background(), request, &response)
 
 			if !response.Diagnostics.HasError() && test.expectError {
 				t.Fatal("expected error, got no error")

--- a/int64validator/at_least_sum_of_test.go
+++ b/int64validator/at_least_sum_of_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -15,7 +16,7 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 
 	type testCase struct {
 		val                  attr.Value
-		attributesToSumPaths []*tftypes.AttributePath
+		attributesToSumPaths []path.Path
 		requestConfigRaw     map[string]tftypes.Value
 		expectError          bool
 	}
@@ -32,9 +33,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 15),
@@ -44,9 +45,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -55,9 +56,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 greater than sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 4),
@@ -66,9 +67,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 greater than sum of attributes, when one summed attribute is null": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -77,9 +78,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are null": {
 			val: types.Int64{Null: true},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -88,9 +89,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 returns error when all attributes to sum are null": {
 			val: types.Int64{Value: -1},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -100,9 +101,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 greater than sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -111,9 +112,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are unknown": {
 			val: types.Int64{Unknown: true},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -122,9 +123,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
 			val: types.Int64{Value: -1},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -133,9 +134,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"error when attribute to sum is not Number": {
 			val: types.Int64{Value: 9},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Bool, true),
@@ -149,7 +150,7 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			request := tfsdk.ValidateAttributeRequest{
-				AttributePath:   tftypes.NewAttributePath().WithAttributeName("test"),
+				AttributePath:   path.Root("test"),
 				AttributeConfig: test.val,
 				Config: tfsdk.Config{
 					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),

--- a/int64validator/at_least_sum_of_test.go
+++ b/int64validator/at_least_sum_of_test.go
@@ -15,10 +15,10 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		val                  attr.Value
-		attributesToSumPaths []path.Path
-		requestConfigRaw     map[string]tftypes.Value
-		expectError          bool
+		val                        attr.Value
+		attributesToSumExpressions path.Expressions
+		requestConfigRaw           map[string]tftypes.Value
+		expectError                bool
 	}
 	tests := map[string]testCase{
 		"not an Int64": {
@@ -33,9 +33,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 15),
@@ -45,9 +45,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -56,9 +56,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 greater than sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 4),
@@ -67,9 +67,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 greater than sum of attributes, when one summed attribute is null": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -78,9 +78,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are null": {
 			val: types.Int64{Null: true},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -89,9 +89,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 returns error when all attributes to sum are null": {
 			val: types.Int64{Value: -1},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -101,9 +101,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 greater than sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -112,9 +112,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are unknown": {
 			val: types.Int64{Unknown: true},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -123,9 +123,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
 			val: types.Int64{Value: -1},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -134,9 +134,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		},
 		"error when attribute to sum is not Number": {
 			val: types.Int64{Value: 9},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Bool, true),
@@ -150,8 +150,9 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			request := tfsdk.ValidateAttributeRequest{
-				AttributePath:   path.Root("test"),
-				AttributeConfig: test.val,
+				AttributePath:           path.Root("test"),
+				AttributePathExpression: path.MatchRoot("test"),
+				AttributeConfig:         test.val,
 				Config: tfsdk.Config{
 					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),
 					Schema: tfsdk.Schema{
@@ -166,7 +167,7 @@ func TestAtLeastSumOfValidator(t *testing.T) {
 
 			response := tfsdk.ValidateAttributeResponse{}
 
-			AtLeastSumOf(test.attributesToSumPaths...).Validate(context.Background(), request, &response)
+			AtLeastSumOf(test.attributesToSumExpressions...).Validate(context.Background(), request, &response)
 
 			if !response.Diagnostics.HasError() && test.expectError {
 				t.Fatal("expected error, got no error")

--- a/int64validator/at_least_sum_of_test.go
+++ b/int64validator/at_least_sum_of_test.go
@@ -1,0 +1,144 @@
+package int64validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestAtLeastSumOfValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val                  attr.Value
+		attributesToSumPaths []*tftypes.AttributePath
+		requestConfigRaw     map[string]tftypes.Value
+		expectError          bool
+	}
+	tests := map[string]testCase{
+		"not an Int64": {
+			val:         types.Bool{Value: true},
+			expectError: true,
+		},
+		"unknown Int64": {
+			val: types.Int64{Unknown: true},
+		},
+		"null Int64": {
+			val: types.Int64{Null: true},
+		},
+		"valid integer as Int64 less than sum of attributes": {
+			val: types.Int64{Value: 10},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 15),
+				"two": tftypes.NewValue(tftypes.Number, 15),
+			},
+			expectError: true,
+		},
+		"valid integer as Int64 equal to sum of attributes": {
+			val: types.Int64{Value: 10},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 5),
+				"two": tftypes.NewValue(tftypes.Number, 5),
+			},
+		},
+		"valid integer as Int64 greater than sum of attributes": {
+			val: types.Int64{Value: 10},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 4),
+				"two": tftypes.NewValue(tftypes.Number, 4),
+			},
+		},
+		"valid integer as Int64 greater than sum of attributes, when one summed attribute is null": {
+			val: types.Int64{Value: 10},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, 9),
+			},
+		},
+		"valid integer as Int64 does not return error when all attributes are null": {
+			val: types.Int64{Null: true},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, nil),
+			},
+		},
+		"valid integer as Int64 greater than sum of attributes, when one summed attribute is unknown": {
+			val: types.Int64{Value: 10},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, 9),
+			},
+		},
+		"valid integer as Int64 does not return error when all attributes are unknown": {
+			val: types.Int64{Unknown: true},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			request := tfsdk.ValidateAttributeRequest{
+				AttributePath:   tftypes.NewAttributePath().WithAttributeName("test"),
+				AttributeConfig: test.val,
+				Config: tfsdk.Config{
+					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),
+					Schema: tfsdk.Schema{
+						Attributes: map[string]tfsdk.Attribute{
+							"test": {Type: types.Int64Type},
+							"one":  {Type: types.Int64Type},
+							"two":  {Type: types.Int64Type},
+						},
+					},
+				},
+			}
+
+			response := tfsdk.ValidateAttributeResponse{}
+
+			AtLeastSumOf(test.attributesToSumPaths).Validate(context.Background(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}

--- a/int64validator/at_most_sum_of.go
+++ b/int64validator/at_most_sum_of.go
@@ -1,0 +1,82 @@
+package int64validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/validatordiag"
+)
+
+var _ tfsdk.AttributeValidator = atMostSumOfValidator{}
+
+// atMostSumOfValidator validates that an integer Attribute's value is at most the sum of one
+// or more integer Attributes.
+type atMostSumOfValidator struct {
+	attributesToSumPaths []*tftypes.AttributePath
+}
+
+// Description describes the validation in plain text formatting.
+func (validator atMostSumOfValidator) Description(_ context.Context) string {
+	var attributePaths []string
+	for _, path := range validator.attributesToSumPaths {
+		attributePaths = append(attributePaths, path.String())
+	}
+
+	return fmt.Sprintf("value must be at most sum of %s", strings.Join(attributePaths, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator atMostSumOfValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator atMostSumOfValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
+	i, ok := validateInt(ctx, request, response)
+
+	if !ok {
+		return
+	}
+
+	var sumOfAttribs int64
+
+	for _, path := range validator.attributesToSumPaths {
+		var attribToSum types.Int64
+
+		response.Diagnostics.Append(request.Config.GetAttribute(ctx, path, &attribToSum)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		sumOfAttribs += attribToSum.Value
+	}
+
+	if i > sumOfAttribs {
+
+		response.Diagnostics.Append(validatordiag.AttributeValueDiagnostic(
+			request.AttributePath,
+			validator.Description(ctx),
+			fmt.Sprintf("%d", i),
+		))
+
+		return
+	}
+}
+
+// AtMostSumOf returns an AttributeValidator which ensures that any configured
+// attribute value:
+//
+//     - Is a number, which can be represented by a 64-bit integer.
+//     - Is exclusively at most the sum of the given attributes.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AtMostSumOf(attributesToSum []*tftypes.AttributePath) tfsdk.AttributeValidator {
+	return atMostSumOfValidator{
+		attributesToSumPaths: attributesToSum,
+	}
+}

--- a/int64validator/at_most_sum_of.go
+++ b/int64validator/at_most_sum_of.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -63,22 +64,27 @@ func (av atMostSumOfValidator) Validate(ctx context.Context, request tfsdk.Valid
 				continue
 			}
 
-			var attribToSum types.Int64
-			diags := request.Config.GetAttribute(ctx, mp, &attribToSum)
+			// Get the value
+			var matchedValue attr.Value
+			diags := request.Config.GetAttribute(ctx, mp, &matchedValue)
 			response.Diagnostics.Append(diags...)
-
-			// Collect all errors
 			if diags.HasError() {
 				continue
 			}
 
-			// Delay validation until all involved attribute have a known value
-			if attribToSum.IsUnknown() {
+			if matchedValue.IsUnknown() {
 				return
 			}
 
-			// Attribute is null, so it doesn't contribute to the sum
-			if attribToSum.IsNull() {
+			if matchedValue.IsNull() {
+				continue
+			}
+
+			// We know there is a value, convert it to the expected type
+			var attribToSum types.Int64
+			diags = tfsdk.ValueAs(ctx, matchedValue, &attribToSum)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
 				continue
 			}
 

--- a/int64validator/at_most_sum_of.go
+++ b/int64validator/at_most_sum_of.go
@@ -21,9 +21,9 @@ type atMostSumOfValidator struct {
 }
 
 // Description describes the validation in plain text formatting.
-func (validator atMostSumOfValidator) Description(_ context.Context) string {
+func (av atMostSumOfValidator) Description(_ context.Context) string {
 	var attributePaths []string
-	for _, p := range validator.attributesToSumPathExpressions {
+	for _, p := range av.attributesToSumPathExpressions {
 		attributePaths = append(attributePaths, p.String())
 	}
 
@@ -31,22 +31,23 @@ func (validator atMostSumOfValidator) Description(_ context.Context) string {
 }
 
 // MarkdownDescription describes the validation in Markdown formatting.
-func (validator atMostSumOfValidator) MarkdownDescription(ctx context.Context) string {
-	return validator.Description(ctx)
+func (av atMostSumOfValidator) MarkdownDescription(ctx context.Context) string {
+	return av.Description(ctx)
 }
 
 // Validate performs the validation.
-func (validator atMostSumOfValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
+func (av atMostSumOfValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
 	i, ok := validateInt(ctx, request, response)
-
 	if !ok {
 		return
 	}
 
-	var sumOfAttribs int64
-	var numUnknownAttribsToSum int
+	// Ensure input path expressions resolution against the current attribute
+	expressions := request.AttributePathExpression.MergeExpressions(av.attributesToSumPathExpressions...)
 
-	for _, expression := range validator.attributesToSumPathExpressions {
+	// Sum the value of all the attributes involved, but only if they are all known.
+	var sumOfAttribs int64
+	for _, expression := range expressions {
 		matchedPaths, diags := request.Config.PathMatches(ctx, expression)
 		response.Diagnostics.Append(diags...)
 
@@ -56,8 +57,13 @@ func (validator atMostSumOfValidator) Validate(ctx context.Context, request tfsd
 		}
 
 		for _, mp := range matchedPaths {
-			var attribToSum types.Int64
+			// If the user specifies the same attribute this validator is applied to,
+			// also as part of the input, skip it
+			if mp.Equal(request.AttributePath) {
+				continue
+			}
 
+			var attribToSum types.Int64
 			diags := request.Config.GetAttribute(ctx, mp, &attribToSum)
 			response.Diagnostics.Append(diags...)
 
@@ -66,12 +72,13 @@ func (validator atMostSumOfValidator) Validate(ctx context.Context, request tfsd
 				continue
 			}
 
-			if attribToSum.IsNull() {
-				continue
+			// Delay validation until all involved attribute have a known value
+			if attribToSum.IsUnknown() {
+				return
 			}
 
-			if attribToSum.IsUnknown() {
-				numUnknownAttribsToSum++
+			// Attribute is null, so it doesn't contribute to the sum
+			if attribToSum.IsNull() {
 				continue
 			}
 
@@ -79,14 +86,10 @@ func (validator atMostSumOfValidator) Validate(ctx context.Context, request tfsd
 		}
 	}
 
-	if numUnknownAttribsToSum > 0 {
-		return
-	}
-
 	if i > sumOfAttribs {
 		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.AttributePath,
-			validator.Description(ctx),
+			av.Description(ctx),
 			fmt.Sprintf("%d", i),
 		))
 

--- a/int64validator/at_most_sum_of.go
+++ b/int64validator/at_most_sum_of.go
@@ -79,7 +79,7 @@ func (validator atMostSumOfValidator) Validate(ctx context.Context, request tfsd
 		}
 	}
 
-	if numUnknownAttribsToSum == len(validator.attributesToSumPathExpressions) {
+	if numUnknownAttribsToSum > 0 {
 		return
 	}
 

--- a/int64validator/at_most_sum_of_test.go
+++ b/int64validator/at_most_sum_of_test.go
@@ -15,10 +15,10 @@ func TestAtMostSumOfValidator(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		val                  attr.Value
-		attributesToSumPaths []path.Path
-		requestConfigRaw     map[string]tftypes.Value
-		expectError          bool
+		val                            attr.Value
+		attributesToSumPathExpressions path.Expressions
+		requestConfigRaw               map[string]tftypes.Value
+		expectError                    bool
 	}
 	tests := map[string]testCase{
 		"not an Int64": {
@@ -33,9 +33,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 more than sum of attributes": {
 			val: types.Int64{Value: 11},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -45,9 +45,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -56,9 +56,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes": {
 			val: types.Int64{Value: 7},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 4),
@@ -67,9 +67,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes, when one summed attribute is null": {
 			val: types.Int64{Value: 8},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -78,9 +78,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are null": {
 			val: types.Int64{Null: true},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -89,9 +89,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 returns error when all attributes to sum are null": {
 			val: types.Int64{Value: 1},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -101,9 +101,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 8},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -112,9 +112,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are unknown": {
 			val: types.Int64{Unknown: true},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -123,9 +123,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
 			val: types.Int64{Value: 1},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -134,9 +134,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"error when attribute to sum is not Number": {
 			val: types.Int64{Value: 9},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Bool, true),
@@ -150,8 +150,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			request := tfsdk.ValidateAttributeRequest{
-				AttributePath:   path.Root("test"),
-				AttributeConfig: test.val,
+				AttributePath:           path.Root("test"),
+				AttributePathExpression: path.MatchRoot("test"),
+				AttributeConfig:         test.val,
 				Config: tfsdk.Config{
 					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),
 					Schema: tfsdk.Schema{
@@ -166,7 +167,7 @@ func TestAtMostSumOfValidator(t *testing.T) {
 
 			response := tfsdk.ValidateAttributeResponse{}
 
-			AtMostSumOf(test.attributesToSumPaths...).Validate(context.Background(), request, &response)
+			AtMostSumOf(test.attributesToSumPathExpressions...).Validate(context.Background(), request, &response)
 
 			if !response.Diagnostics.HasError() && test.expectError {
 				t.Fatal("expected error, got no error")

--- a/int64validator/at_most_sum_of_test.go
+++ b/int64validator/at_most_sum_of_test.go
@@ -1,0 +1,144 @@
+package int64validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestAtMostSumOfValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val                  attr.Value
+		attributesToSumPaths []*tftypes.AttributePath
+		requestConfigRaw     map[string]tftypes.Value
+		expectError          bool
+	}
+	tests := map[string]testCase{
+		"not an Int64": {
+			val:         types.Bool{Value: true},
+			expectError: true,
+		},
+		"unknown Int64": {
+			val: types.Int64{Unknown: true},
+		},
+		"null Int64": {
+			val: types.Int64{Null: true},
+		},
+		"valid integer as Int64 more than sum of attributes": {
+			val: types.Int64{Value: 11},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 5),
+				"two": tftypes.NewValue(tftypes.Number, 5),
+			},
+			expectError: true,
+		},
+		"valid integer as Int64 equal to sum of attributes": {
+			val: types.Int64{Value: 10},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 5),
+				"two": tftypes.NewValue(tftypes.Number, 5),
+			},
+		},
+		"valid integer as Int64 less than sum of attributes": {
+			val: types.Int64{Value: 7},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 4),
+				"two": tftypes.NewValue(tftypes.Number, 4),
+			},
+		},
+		"valid integer as Int64 less than sum of attributes, when one summed attribute is null": {
+			val: types.Int64{Value: 8},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, 9),
+			},
+		},
+		"valid integer as Int64 does not return error when all attributes are null": {
+			val: types.Int64{Null: true},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, nil),
+			},
+		},
+		"valid integer as Int64 less than sum of attributes, when one summed attribute is unknown": {
+			val: types.Int64{Value: 8},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, 9),
+			},
+		},
+		"valid integer as Int64 does not return error when all attributes are unknown": {
+			val: types.Int64{Unknown: true},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			request := tfsdk.ValidateAttributeRequest{
+				AttributePath:   tftypes.NewAttributePath().WithAttributeName("test"),
+				AttributeConfig: test.val,
+				Config: tfsdk.Config{
+					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),
+					Schema: tfsdk.Schema{
+						Attributes: map[string]tfsdk.Attribute{
+							"test": {Type: types.Int64Type},
+							"one":  {Type: types.Int64Type},
+							"two":  {Type: types.Int64Type},
+						},
+					},
+				},
+			}
+
+			response := tfsdk.ValidateAttributeResponse{}
+
+			AtMostSumOf(test.attributesToSumPaths).Validate(context.Background(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}

--- a/int64validator/at_most_sum_of_test.go
+++ b/int64validator/at_most_sum_of_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -15,7 +16,7 @@ func TestAtMostSumOfValidator(t *testing.T) {
 
 	type testCase struct {
 		val                  attr.Value
-		attributesToSumPaths []*tftypes.AttributePath
+		attributesToSumPaths []path.Path
 		requestConfigRaw     map[string]tftypes.Value
 		expectError          bool
 	}
@@ -32,9 +33,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 more than sum of attributes": {
 			val: types.Int64{Value: 11},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -44,9 +45,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -55,9 +56,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes": {
 			val: types.Int64{Value: 7},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 4),
@@ -66,9 +67,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes, when one summed attribute is null": {
 			val: types.Int64{Value: 8},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -77,9 +78,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are null": {
 			val: types.Int64{Null: true},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -88,9 +89,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 returns error when all attributes to sum are null": {
 			val: types.Int64{Value: 1},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -100,9 +101,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 8},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -111,9 +112,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are unknown": {
 			val: types.Int64{Unknown: true},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -122,9 +123,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
 			val: types.Int64{Value: 1},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -133,9 +134,9 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		},
 		"error when attribute to sum is not Number": {
 			val: types.Int64{Value: 9},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Bool, true),
@@ -149,7 +150,7 @@ func TestAtMostSumOfValidator(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			request := tfsdk.ValidateAttributeRequest{
-				AttributePath:   tftypes.NewAttributePath().WithAttributeName("test"),
+				AttributePath:   path.Root("test"),
 				AttributeConfig: test.val,
 				Config: tfsdk.Config{
 					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),

--- a/int64validator/at_most_sum_of_test.go
+++ b/int64validator/at_most_sum_of_test.go
@@ -86,6 +86,18 @@ func TestAtMostSumOfValidator(t *testing.T) {
 				"two": tftypes.NewValue(tftypes.Number, nil),
 			},
 		},
+		"valid integer as Int64 returns error when all attributes to sum are null": {
+			val: types.Int64{Value: 1},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, nil),
+			},
+			expectError: true,
+		},
 		"valid integer as Int64 less than sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 8},
 			attributesToSumPaths: []*tftypes.AttributePath{
@@ -107,6 +119,29 @@ func TestAtMostSumOfValidator(t *testing.T) {
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 			},
+		},
+		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
+			val: types.Int64{Value: 1},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+		"error when attribute to sum is not Number": {
+			val: types.Int64{Value: 9},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Bool, true),
+				"two": tftypes.NewValue(tftypes.Number, 9),
+			},
+			expectError: true,
 		},
 	}
 
@@ -130,7 +165,7 @@ func TestAtMostSumOfValidator(t *testing.T) {
 
 			response := tfsdk.ValidateAttributeResponse{}
 
-			AtMostSumOf(test.attributesToSumPaths).Validate(context.Background(), request, &response)
+			AtMostSumOf(test.attributesToSumPaths...).Validate(context.Background(), request, &response)
 
 			if !response.Diagnostics.HasError() && test.expectError {
 				t.Fatal("expected error, got no error")

--- a/int64validator/equal_to_sum_of.go
+++ b/int64validator/equal_to_sum_of.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/hashicorp/terraform-plugin-go/tftypes"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 )
 
 var _ tfsdk.AttributeValidator = equalToSumOfValidator{}
@@ -17,14 +17,14 @@ var _ tfsdk.AttributeValidator = equalToSumOfValidator{}
 // equalToSumOfValidator validates that an integer Attribute's value equals the sum of one
 // or more integer Attributes.
 type equalToSumOfValidator struct {
-	attributesToSumPaths []*tftypes.AttributePath
+	attributesToSumPaths []path.Path
 }
 
 // Description describes the validation in plain text formatting.
 func (validator equalToSumOfValidator) Description(_ context.Context) string {
 	var attributePaths []string
-	for _, path := range validator.attributesToSumPaths {
-		attributePaths = append(attributePaths, path.String())
+	for _, p := range validator.attributesToSumPaths {
+		attributePaths = append(attributePaths, p.String())
 	}
 
 	return fmt.Sprintf("value must be equal to the sum of %s", strings.Join(attributePaths, " + "))
@@ -46,10 +46,10 @@ func (validator equalToSumOfValidator) Validate(ctx context.Context, request tfs
 	var sumOfAttribs int64
 	var numUnknownAttribsToSum int
 
-	for _, path := range validator.attributesToSumPaths {
+	for _, p := range validator.attributesToSumPaths {
 		var attribToSum types.Int64
 
-		response.Diagnostics.Append(request.Config.GetAttribute(ctx, path, &attribToSum)...)
+		response.Diagnostics.Append(request.Config.GetAttribute(ctx, p, &attribToSum)...)
 		if response.Diagnostics.HasError() {
 			return
 		}
@@ -71,7 +71,7 @@ func (validator equalToSumOfValidator) Validate(ctx context.Context, request tfs
 	}
 
 	if i != sumOfAttribs {
-		response.Diagnostics.Append(validatordiag.AttributeValueDiagnostic(
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
 			request.AttributePath,
 			validator.Description(ctx),
 			fmt.Sprintf("%d", i),
@@ -88,7 +88,7 @@ func (validator equalToSumOfValidator) Validate(ctx context.Context, request tfs
 //     - Is equal to the sum of the given attributes.
 //
 // Null (unconfigured) and unknown (known after apply) values are skipped.
-func EqualToSumOf(attributesToSum ...*tftypes.AttributePath) tfsdk.AttributeValidator {
+func EqualToSumOf(attributesToSum ...path.Path) tfsdk.AttributeValidator {
 	return equalToSumOfValidator{
 		attributesToSumPaths: attributesToSum,
 	}

--- a/int64validator/equal_to_sum_of.go
+++ b/int64validator/equal_to_sum_of.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -63,22 +64,27 @@ func (av equalToSumOfValidator) Validate(ctx context.Context, request tfsdk.Vali
 				continue
 			}
 
-			var attribToSum types.Int64
-			diags := request.Config.GetAttribute(ctx, mp, &attribToSum)
+			// Get the value
+			var matchedValue attr.Value
+			diags := request.Config.GetAttribute(ctx, mp, &matchedValue)
 			response.Diagnostics.Append(diags...)
-
-			// Collect all errors
 			if diags.HasError() {
 				continue
 			}
 
-			// Delay validation until all involved attribute have a known value
-			if attribToSum.IsUnknown() {
+			if matchedValue.IsUnknown() {
 				return
 			}
 
-			// Attribute is null, so it doesn't contribute to the sum
-			if attribToSum.IsNull() {
+			if matchedValue.IsNull() {
+				continue
+			}
+
+			// We know there is a value, convert it to the expected type
+			var attribToSum types.Int64
+			diags = tfsdk.ValueAs(ctx, matchedValue, &attribToSum)
+			response.Diagnostics.Append(diags...)
+			if diags.HasError() {
 				continue
 			}
 

--- a/int64validator/equal_to_sum_of.go
+++ b/int64validator/equal_to_sum_of.go
@@ -79,7 +79,7 @@ func (validator equalToSumOfValidator) Validate(ctx context.Context, request tfs
 		}
 	}
 
-	if numUnknownAttribsToSum == len(validator.attributesToSumPathExpressions) {
+	if numUnknownAttribsToSum > 0 {
 		return
 	}
 

--- a/int64validator/equal_to_sum_of.go
+++ b/int64validator/equal_to_sum_of.go
@@ -1,0 +1,82 @@
+package int64validator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/validatordiag"
+)
+
+var _ tfsdk.AttributeValidator = equalToSumOfValidator{}
+
+// equalToSumOfValidator validates that an integer Attribute's value equals the sum of one
+// or more integer Attributes.
+type equalToSumOfValidator struct {
+	attributesToSumPaths []*tftypes.AttributePath
+}
+
+// Description describes the validation in plain text formatting.
+func (validator equalToSumOfValidator) Description(_ context.Context) string {
+	var attributePaths []string
+	for _, path := range validator.attributesToSumPaths {
+		attributePaths = append(attributePaths, path.String())
+	}
+
+	return fmt.Sprintf("value must be equal to the sum of %s", strings.Join(attributePaths, " + "))
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator equalToSumOfValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Validate performs the validation.
+func (validator equalToSumOfValidator) Validate(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) {
+	i, ok := validateInt(ctx, request, response)
+
+	if !ok {
+		return
+	}
+
+	var sumOfAttribs int64
+
+	for _, path := range validator.attributesToSumPaths {
+		var attribToSum types.Int64
+
+		response.Diagnostics.Append(request.Config.GetAttribute(ctx, path, &attribToSum)...)
+		if response.Diagnostics.HasError() {
+			return
+		}
+
+		sumOfAttribs += attribToSum.Value
+	}
+
+	if i != sumOfAttribs {
+
+		response.Diagnostics.Append(validatordiag.AttributeValueDiagnostic(
+			request.AttributePath,
+			validator.Description(ctx),
+			fmt.Sprintf("%d", i),
+		))
+
+		return
+	}
+}
+
+// EqualToSumOf returns an AttributeValidator which ensures that any configured
+// attribute value:
+//
+//     - Is a number, which can be represented by a 64-bit integer.
+//     - Is exclusively equal to the sum of the given attributes.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func EqualToSumOf(attributesToSum []*tftypes.AttributePath) tfsdk.AttributeValidator {
+	return equalToSumOfValidator{
+		attributesToSumPaths: attributesToSum,
+	}
+}

--- a/int64validator/equal_to_sum_of_test.go
+++ b/int64validator/equal_to_sum_of_test.go
@@ -15,10 +15,10 @@ func TestEqualToSumOfValidator(t *testing.T) {
 	t.Parallel()
 
 	type testCase struct {
-		val                  attr.Value
-		attributesToSumPaths []path.Path
-		requestConfigRaw     map[string]tftypes.Value
-		expectError          bool
+		val                            attr.Value
+		attributesToSumPathExpressions path.Expressions
+		requestConfigRaw               map[string]tftypes.Value
+		expectError                    bool
 	}
 	tests := map[string]testCase{
 		"not an Int64": {
@@ -33,9 +33,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 more than sum of attributes": {
 			val: types.Int64{Value: 11},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -45,9 +45,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes": {
 			val: types.Int64{Value: 9},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -57,9 +57,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -68,9 +68,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes, when one summed attribute is null": {
 			val: types.Int64{Value: 8},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -79,9 +79,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are null": {
 			val: types.Int64{Null: true},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -90,9 +90,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 returns error when all attributes to sum are null": {
 			val: types.Int64{Value: 1},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -102,9 +102,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 8},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -113,9 +113,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are unknown": {
 			val: types.Int64{Unknown: true},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -124,9 +124,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
 			val: types.Int64{Value: 1},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -135,9 +135,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"error when attribute to sum is not Number": {
 			val: types.Int64{Value: 9},
-			attributesToSumPaths: []path.Path{
-				path.Root("one"),
-				path.Root("two"),
+			attributesToSumPathExpressions: path.Expressions{
+				path.MatchRoot("one"),
+				path.MatchRoot("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Bool, true),
@@ -151,8 +151,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			request := tfsdk.ValidateAttributeRequest{
-				AttributePath:   path.Root("test"),
-				AttributeConfig: test.val,
+				AttributePath:           path.Root("test"),
+				AttributePathExpression: path.MatchRoot("test"),
+				AttributeConfig:         test.val,
 				Config: tfsdk.Config{
 					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),
 					Schema: tfsdk.Schema{
@@ -167,7 +168,7 @@ func TestEqualToSumOfValidator(t *testing.T) {
 
 			response := tfsdk.ValidateAttributeResponse{}
 
-			EqualToSumOf(test.attributesToSumPaths...).Validate(context.Background(), request, &response)
+			EqualToSumOf(test.attributesToSumPathExpressions...).Validate(context.Background(), request, &response)
 
 			if !response.Diagnostics.HasError() && test.expectError {
 				t.Fatal("expected error, got no error")

--- a/int64validator/equal_to_sum_of_test.go
+++ b/int64validator/equal_to_sum_of_test.go
@@ -87,6 +87,18 @@ func TestEqualToSumOfValidator(t *testing.T) {
 				"two": tftypes.NewValue(tftypes.Number, nil),
 			},
 		},
+		"valid integer as Int64 returns error when all attributes to sum are null": {
+			val: types.Int64{Value: 1},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, nil),
+			},
+			expectError: true,
+		},
 		"valid integer as Int64 equal to sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 8},
 			attributesToSumPaths: []*tftypes.AttributePath{
@@ -108,6 +120,29 @@ func TestEqualToSumOfValidator(t *testing.T) {
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
 			},
+		},
+		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
+			val: types.Int64{Value: 1},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+		"error when attribute to sum is not Number": {
+			val: types.Int64{Value: 9},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Bool, true),
+				"two": tftypes.NewValue(tftypes.Number, 9),
+			},
+			expectError: true,
 		},
 	}
 
@@ -131,7 +166,7 @@ func TestEqualToSumOfValidator(t *testing.T) {
 
 			response := tfsdk.ValidateAttributeResponse{}
 
-			EqualToSumOf(test.attributesToSumPaths).Validate(context.Background(), request, &response)
+			EqualToSumOf(test.attributesToSumPaths...).Validate(context.Background(), request, &response)
 
 			if !response.Diagnostics.HasError() && test.expectError {
 				t.Fatal("expected error, got no error")

--- a/int64validator/equal_to_sum_of_test.go
+++ b/int64validator/equal_to_sum_of_test.go
@@ -1,0 +1,145 @@
+package int64validator
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+func TestEqualToSumOfValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val                  attr.Value
+		attributesToSumPaths []*tftypes.AttributePath
+		requestConfigRaw     map[string]tftypes.Value
+		expectError          bool
+	}
+	tests := map[string]testCase{
+		"not an Int64": {
+			val:         types.Bool{Value: true},
+			expectError: true,
+		},
+		"unknown Int64": {
+			val: types.Int64{Unknown: true},
+		},
+		"null Int64": {
+			val: types.Int64{Null: true},
+		},
+		"valid integer as Int64 more than sum of attributes": {
+			val: types.Int64{Value: 11},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 5),
+				"two": tftypes.NewValue(tftypes.Number, 5),
+			},
+			expectError: true,
+		},
+		"valid integer as Int64 less than sum of attributes": {
+			val: types.Int64{Value: 9},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 5),
+				"two": tftypes.NewValue(tftypes.Number, 5),
+			},
+			expectError: true,
+		},
+		"valid integer as Int64 equal to sum of attributes": {
+			val: types.Int64{Value: 10},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, 5),
+				"two": tftypes.NewValue(tftypes.Number, 5),
+			},
+		},
+		"valid integer as Int64 equal to sum of attributes, when one summed attribute is null": {
+			val: types.Int64{Value: 8},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, 8),
+			},
+		},
+		"valid integer as Int64 does not return error when all attributes are null": {
+			val: types.Int64{Null: true},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, nil),
+				"two": tftypes.NewValue(tftypes.Number, nil),
+			},
+		},
+		"valid integer as Int64 equal to sum of attributes, when one summed attribute is unknown": {
+			val: types.Int64{Value: 8},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, 8),
+			},
+		},
+		"valid integer as Int64 does not return error when all attributes are unknown": {
+			val: types.Int64{Unknown: true},
+			attributesToSumPaths: []*tftypes.AttributePath{
+				tftypes.NewAttributePath().WithAttributeName("one"),
+				tftypes.NewAttributePath().WithAttributeName("two"),
+			},
+			requestConfigRaw: map[string]tftypes.Value{
+				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+				"two": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			request := tfsdk.ValidateAttributeRequest{
+				AttributePath:   tftypes.NewAttributePath().WithAttributeName("test"),
+				AttributeConfig: test.val,
+				Config: tfsdk.Config{
+					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),
+					Schema: tfsdk.Schema{
+						Attributes: map[string]tfsdk.Attribute{
+							"test": {Type: types.Int64Type},
+							"one":  {Type: types.Int64Type},
+							"two":  {Type: types.Int64Type},
+						},
+					},
+				},
+			}
+
+			response := tfsdk.ValidateAttributeResponse{}
+
+			EqualToSumOf(test.attributesToSumPaths).Validate(context.Background(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}

--- a/int64validator/equal_to_sum_of_test.go
+++ b/int64validator/equal_to_sum_of_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-go/tftypes"
@@ -15,7 +16,7 @@ func TestEqualToSumOfValidator(t *testing.T) {
 
 	type testCase struct {
 		val                  attr.Value
-		attributesToSumPaths []*tftypes.AttributePath
+		attributesToSumPaths []path.Path
 		requestConfigRaw     map[string]tftypes.Value
 		expectError          bool
 	}
@@ -32,9 +33,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 more than sum of attributes": {
 			val: types.Int64{Value: 11},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -44,9 +45,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 less than sum of attributes": {
 			val: types.Int64{Value: 9},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -56,9 +57,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes": {
 			val: types.Int64{Value: 10},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, 5),
@@ -67,9 +68,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes, when one summed attribute is null": {
 			val: types.Int64{Value: 8},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -78,9 +79,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are null": {
 			val: types.Int64{Null: true},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -89,9 +90,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 returns error when all attributes to sum are null": {
 			val: types.Int64{Value: 1},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, nil),
@@ -101,9 +102,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 equal to sum of attributes, when one summed attribute is unknown": {
 			val: types.Int64{Value: 8},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -112,9 +113,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes are unknown": {
 			val: types.Int64{Unknown: true},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -123,9 +124,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"valid integer as Int64 does not return error when all attributes to sum are unknown": {
 			val: types.Int64{Value: 1},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Number, tftypes.UnknownValue),
@@ -134,9 +135,9 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		},
 		"error when attribute to sum is not Number": {
 			val: types.Int64{Value: 9},
-			attributesToSumPaths: []*tftypes.AttributePath{
-				tftypes.NewAttributePath().WithAttributeName("one"),
-				tftypes.NewAttributePath().WithAttributeName("two"),
+			attributesToSumPaths: []path.Path{
+				path.Root("one"),
+				path.Root("two"),
 			},
 			requestConfigRaw: map[string]tftypes.Value{
 				"one": tftypes.NewValue(tftypes.Bool, true),
@@ -150,7 +151,7 @@ func TestEqualToSumOfValidator(t *testing.T) {
 		name, test := name, test
 		t.Run(name, func(t *testing.T) {
 			request := tfsdk.ValidateAttributeRequest{
-				AttributePath:   tftypes.NewAttributePath().WithAttributeName("test"),
+				AttributePath:   path.Root("test"),
 				AttributeConfig: test.val,
 				Config: tfsdk.Config{
 					Raw: tftypes.NewValue(tftypes.Object{}, test.requestConfigRaw),

--- a/int64validator/type_validation.go
+++ b/int64validator/type_validation.go
@@ -3,26 +3,20 @@ package int64validator
 import (
 	"context"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // validateInt ensures that the request contains an Int64 value.
 func validateInt(ctx context.Context, request tfsdk.ValidateAttributeRequest, response *tfsdk.ValidateAttributeResponse) (int64, bool) {
-	t := request.AttributeConfig.Type(ctx)
-	if t != types.Int64Type {
-		response.Diagnostics.Append(validatordiag.InvalidAttributeTypeDiagnostic(
-			request.AttributePath,
-			"Expected value of type int64",
-			t.String(),
-		))
+	var i types.Int64
+	diags := tfsdk.ValueAs(ctx, request.AttributeConfig, &i)
+	response.Diagnostics.Append(diags...)
+	if diags.HasError() {
 		return 0, false
 	}
 
-	i := request.AttributeConfig.(types.Int64)
-
-	if i.Unknown || i.Null {
+	if i.IsUnknown() || i.IsNull() {
 		return 0, false
 	}
 

--- a/int64validator/type_validation_test.go
+++ b/int64validator/type_validation_test.go
@@ -14,9 +14,11 @@ func TestValidateInt(t *testing.T) {
 	t.Parallel()
 
 	testCases := map[string]struct {
-		request       tfsdk.ValidateAttributeRequest
-		expectedInt64 int64
-		expectedOk    bool
+		request             tfsdk.ValidateAttributeRequest
+		expectedInt64       int64
+		expectedOk          bool
+		expectedDiagSummary string
+		expectedDiagDetail  string
 	}{
 		"invalid-type": {
 			request: tfsdk.ValidateAttributeRequest{
@@ -24,8 +26,10 @@ func TestValidateInt(t *testing.T) {
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
-			expectedInt64: 0.0,
-			expectedOk:    false,
+			expectedInt64:       0.0,
+			expectedOk:          false,
+			expectedDiagSummary: "Value Conversion Error",
+			expectedDiagDetail:  "An unexpected error was encountered trying to convert into a Terraform value. This is always an error in the provider. Please report the following to the provider developer:\n\nCannot use attr.Value types.Int64, only types.Bool is supported because types.primitive is the type in the schema",
 		},
 		"int64-null": {
 			request: tfsdk.ValidateAttributeRequest{
@@ -33,8 +37,10 @@ func TestValidateInt(t *testing.T) {
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
-			expectedInt64: 0.0,
-			expectedOk:    false,
+			expectedInt64:       0.0,
+			expectedOk:          false,
+			expectedDiagSummary: "",
+			expectedDiagDetail:  "",
 		},
 		"int64-value": {
 			request: tfsdk.ValidateAttributeRequest{
@@ -51,8 +57,10 @@ func TestValidateInt(t *testing.T) {
 				AttributePath:           path.Root("test"),
 				AttributePathExpression: path.MatchRoot("test"),
 			},
-			expectedInt64: 0.0,
-			expectedOk:    false,
+			expectedInt64:       0.0,
+			expectedOk:          false,
+			expectedDiagSummary: "",
+			expectedDiagDetail:  "",
 		},
 	}
 
@@ -62,10 +70,25 @@ func TestValidateInt(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			gotInt64, gotOk := validateInt(context.Background(), testCase.request, &tfsdk.ValidateAttributeResponse{})
+			res := tfsdk.ValidateAttributeResponse{}
+			gotInt64, gotOk := validateInt(context.Background(), testCase.request, &res)
+
+			if res.Diagnostics.HasError() {
+				if res.Diagnostics.ErrorsCount() != 1 {
+					t.Errorf("expected an error but found none")
+				} else {
+					if diff := cmp.Diff(res.Diagnostics[0].Summary(), testCase.expectedDiagSummary); diff != "" {
+						t.Errorf("unexpected diagnostic summary difference: %s", diff)
+					}
+
+					if diff := cmp.Diff(res.Diagnostics[0].Detail(), testCase.expectedDiagDetail); diff != "" {
+						t.Errorf("unexpected diagnostic summary difference: %s", diff)
+					}
+				}
+			}
 
 			if diff := cmp.Diff(gotInt64, testCase.expectedInt64); diff != "" {
-				t.Errorf("unexpected float64 difference: %s", diff)
+				t.Errorf("unexpected int64 difference: %s", diff)
 			}
 
 			if diff := cmp.Diff(gotOk, testCase.expectedOk); diff != "" {


### PR DESCRIPTION
Closes: #20 

Couple of things:
- If the attributes that are being summed are `null` this validator silently ignores that fact.
- If all of the attributes that are being summed are `unknown`, no errors are emitted as it's not possible to perform the validation.
- ~~If this looks like it might be useful, let me know and I'll add `atMostSumOf` and any other permutations that you think are appropriate into the same PR.~~ Have added `atLeastSumOf` and `equalToSumOf`. 