### PR TITLE
Adding `GetErrors` func and `GetWarnings` func to validatordiag pkg

### DIFF
--- a/helpers/validatordiag/diag.go
+++ b/helpers/validatordiag/diag.go
@@ -79,6 +79,32 @@ func WarningsCount(diags diag.Diagnostics) int {
 	return count
 }
 
+// GetErrors returns all the diag.Diagnostic in diag.Diagnostics that are diag.SeverityError.
+func GetErrors(diags diag.Diagnostics) diag.Diagnostics {
+	var dd diag.Diagnostics
+
+	for _, d := range diags {
+		if diag.SeverityError == d.Severity() {
+			dd = append(dd, d)
+		}
+	}
+
+	return dd
+}
+
+// GetWarnings returns all the diag.Diagnostic in diag.Diagnostics that are diag.SeverityWarning.
+func GetWarnings(diags diag.Diagnostics) diag.Diagnostics {
+	var dd diag.Diagnostics
+
+	for _, d := range diags {
+		if diag.SeverityWarning == d.Severity() {
+			dd = append(dd, d)
+		}
+	}
+
+	return dd
+}
+
 // capitalize will uppercase the first letter in a UTF-8 string.
 func capitalize(str string) string {
 	if str == "" {

--- a/helpers/validatordiag/diag_test.go
+++ b/helpers/validatordiag/diag_test.go
@@ -2,6 +2,9 @@ package validatordiag
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
 
 func TestCapitalize(t *testing.T) {
@@ -36,6 +39,68 @@ func TestCapitalize(t *testing.T) {
 			got := capitalize(test.input)
 
 			if got != test.expected {
+				t.Fatalf("expected: %q, got: %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestGetErrors(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    diag.Diagnostics
+		expected diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"errors": {
+			input: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error", ""),
+				diag.NewWarningDiagnostic("Warning", ""),
+			},
+			expected: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error", ""),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := GetErrors(test.input)
+
+			if diff := cmp.Diff(test.expected, got); diff != "" {
+				t.Fatalf("expected: %q, got: %q", test.expected, got)
+			}
+		})
+	}
+}
+
+func TestGetWarnings(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		input    diag.Diagnostics
+		expected diag.Diagnostics
+	}
+	tests := map[string]testCase{
+		"errors": {
+			input: diag.Diagnostics{
+				diag.NewErrorDiagnostic("Error", ""),
+				diag.NewWarningDiagnostic("Warning", ""),
+			},
+			expected: diag.Diagnostics{
+				diag.NewWarningDiagnostic("Warning", ""),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			got := GetWarnings(test.input)
+
+			if diff := cmp.Diff(test.expected, got); diff != "" {
 				t.Fatalf("expected: %q, got: %q", test.expected, got)
 			}
 		})


### PR DESCRIPTION
This PR adds the following functions to the validatordiag pkg:

- `GetErrors(diags diag.Diagnostics) diag.Diagnostics`
- `GetWarnings(diags diag.Diagnostics) diag.Diagnostics`

**NOTE** If https://github.com/hashicorp/terraform-plugin-framework/pull/392 is merged then this PR can be altered to remove `ErrorsCount()`, `WarningsCount()`, `Errors()` and `Warnings()`.