### PR TITLE
Return all errors from Map KeysAre validators

### DIFF
--- a/.changelog/74.txt
+++ b/.changelog/74.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+mapvalidator: Updated `KeysAre()` to return all errors instead of just the first
+```

--- a/mapvalidator/keys_are.go
+++ b/mapvalidator/keys_are.go
@@ -52,9 +52,6 @@ func (v keysAreValidator) Validate(ctx context.Context, req tfsdk.ValidateAttrib
 
 		for _, validator := range v.keyValidators {
 			validator.Validate(ctx, request, resp)
-			if resp.Diagnostics.HasError() {
-				return
-			}
 		}
 	}
 }

--- a/mapvalidator/keys_are_test.go
+++ b/mapvalidator/keys_are_test.go
@@ -19,28 +19,28 @@ func TestKeysAreValidator(t *testing.T) {
 	type testCase struct {
 		val               attr.Value
 		keysAreValidators []tfsdk.AttributeValidator
-		expectError       bool
+		expectErrorsCount int
 	}
 	tests := map[string]testCase{
 		"not Map": {
 			val: types.List{
 				ElemType: types.StringType,
 			},
-			expectError: true,
+			expectErrorsCount: 1,
 		},
 		"Map unknown": {
 			val: types.Map{
 				Unknown:  true,
 				ElemType: types.StringType,
 			},
-			expectError: false,
+			expectErrorsCount: 0,
 		},
 		"Map null": {
 			val: types.Map{
 				Null:     true,
 				ElemType: types.StringType,
 			},
-			expectError: false,
+			expectErrorsCount: 0,
 		},
 		"Map key invalid": {
 			val: types.Map{
@@ -53,7 +53,7 @@ func TestKeysAreValidator(t *testing.T) {
 			keysAreValidators: []tfsdk.AttributeValidator{
 				stringvalidator.LengthAtLeast(4),
 			},
-			expectError: true,
+			expectErrorsCount: 2,
 		},
 		"Map key invalid for second validator": {
 			val: types.Map{
@@ -67,7 +67,7 @@ func TestKeysAreValidator(t *testing.T) {
 				stringvalidator.LengthAtLeast(2),
 				stringvalidator.LengthAtLeast(6),
 			},
-			expectError: true,
+			expectErrorsCount: 2,
 		},
 		"Map keys wrong type for validator": {
 			val: types.Map{
@@ -80,7 +80,20 @@ func TestKeysAreValidator(t *testing.T) {
 			keysAreValidators: []tfsdk.AttributeValidator{
 				int64validator.AtLeast(6),
 			},
-			expectError: true,
+			expectErrorsCount: 1,
+		},
+		"Map keys for invalid multiple validators": {
+			val: types.Map{
+				ElemType: types.StringType,
+				Elems: map[string]attr.Value{
+					"one": types.String{Value: "first"},
+				},
+			},
+			keysAreValidators: []tfsdk.AttributeValidator{
+				stringvalidator.LengthAtLeast(5),
+				stringvalidator.LengthAtLeast(6),
+			},
+			expectErrorsCount: 2,
 		},
 		"Map keys valid": {
 			val: types.Map{
@@ -93,7 +106,7 @@ func TestKeysAreValidator(t *testing.T) {
 			keysAreValidators: []tfsdk.AttributeValidator{
 				stringvalidator.LengthAtLeast(3),
 			},
-			expectError: false,
+			expectErrorsCount: 0,
 		},
 	}
 
@@ -108,12 +121,8 @@ func TestKeysAreValidator(t *testing.T) {
 			response := tfsdk.ValidateAttributeResponse{}
 			KeysAre(test.keysAreValidators...).Validate(context.TODO(), request, &response)
 
-			if !response.Diagnostics.HasError() && test.expectError {
-				t.Fatal("expected error, got no error")
-			}
-
-			if response.Diagnostics.HasError() && !test.expectError {
-				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			if response.Diagnostics.ErrorsCount() != test.expectErrorsCount {
+				t.Fatalf("expected %d errors, but got %d: %s", test.expectErrorsCount, response.Diagnostics.ErrorsCount(), response.Diagnostics)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #73

Removes the `resp.Diagnostics.HasError()` check exiting the loop early so that
all validators are checked instead of returning after the first error.

Updates the test to check the number of errors instead. To avoid redundancy with
the `expectError` bool, this changes all test cases to just check for the
specific number of errors.
