### PR TITLE
Fix configvalidator dropping previous diags

### DIFF
--- a/internal/configvalidator/at_least_one_of.go
+++ b/internal/configvalidator/at_least_one_of.go
@@ -31,15 +31,15 @@ func (v AtLeastOneOfValidator) MarkdownDescription(_ context.Context) string {
 }
 
 func (v AtLeastOneOfValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v AtLeastOneOfValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v AtLeastOneOfValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v AtLeastOneOfValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {

--- a/internal/configvalidator/conflicting.go
+++ b/internal/configvalidator/conflicting.go
@@ -32,15 +32,15 @@ func (v ConflictingValidator) MarkdownDescription(_ context.Context) string {
 }
 
 func (v ConflictingValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v ConflictingValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v ConflictingValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v ConflictingValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {

--- a/internal/configvalidator/exactly_one_of.go
+++ b/internal/configvalidator/exactly_one_of.go
@@ -32,15 +32,15 @@ func (v ExactlyOneOfValidator) MarkdownDescription(_ context.Context) string {
 }
 
 func (v ExactlyOneOfValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v ExactlyOneOfValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v ExactlyOneOfValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v ExactlyOneOfValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {

--- a/internal/configvalidator/required_together.go
+++ b/internal/configvalidator/required_together.go
@@ -32,15 +32,15 @@ func (v RequiredTogetherValidator) MarkdownDescription(_ context.Context) string
 }
 
 func (v RequiredTogetherValidator) ValidateDataSource(ctx context.Context, req datasource.ValidateConfigRequest, resp *datasource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v RequiredTogetherValidator) ValidateProvider(ctx context.Context, req provider.ValidateConfigRequest, resp *provider.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v RequiredTogetherValidator) ValidateResource(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	resp.Diagnostics = v.Validate(ctx, req.Config)
+	resp.Diagnostics.Append(v.Validate(ctx, req.Config)...)
 }
 
 func (v RequiredTogetherValidator) Validate(ctx context.Context, config tfsdk.Config) diag.Diagnostics {


### PR DESCRIPTION
Before if you had something like this

```go
return []resource.ConfigValidator{
  resourcevalidator.ExactlyOneOf(
    path.MatchRoot("a"),
    path.MatchRoot("b"),
  ),
  resourcevalidator.ExactlyOneOf(
    path.MatchRoot("c"),
    path.MatchRoot("d"),
  ),
}
```
the second validator overwrites the diags from the first one, ignoring it completely.

Alternatively this could also be fixed in the framework itself like [here](https://github.com/hashicorp/terraform-plugin-framework/blob/499f24a6e7d0db68f56f325648808d5375ddf90c/internal/fwserver/block_validation.go#L340):
```go
for _, blockValidator := range block.SetValidators() {
  // Instantiate a new response for each request to prevent validators
  // from modifying or removing diagnostics.
```