### PR TITLE
Add `--plan` flag to license check

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -14,4 +14,4 @@ jobs:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
       - run: copywrite headers --plan
-      - run: copywrite license
+      - run: copywrite license --plan


### PR DESCRIPTION
- Ensures that an error is thrown if the license is malformed or missing