### PR TITLE
Remove double quoting in string validator descriptions

### DIFF
--- a/.changes/unreleased/BUG FIXES-20230801-104745.yaml
+++ b/.changes/unreleased/BUG FIXES-20230801-104745.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'stringvalidator: Removed double quoting in `Description` returned from `NoneOf`,
+  `NoneOfCaseInsensitive`, `OneOf` and `OneOfCaseInsensitive` validators'
+time: 2023-08-01T10:47:45.629204+01:00
+custom:
+  Issue: "152"

--- a/stringvalidator/none_of.go
+++ b/stringvalidator/none_of.go
@@ -25,7 +25,7 @@ func (v noneOfValidator) Description(ctx context.Context) string {
 }
 
 func (v noneOfValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("value must be none of: %q", v.values)
+	return fmt.Sprintf("value must be none of: %s", v.values)
 }
 
 func (v noneOfValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {

--- a/stringvalidator/none_of_case_insensitive.go
+++ b/stringvalidator/none_of_case_insensitive.go
@@ -26,7 +26,7 @@ func (v noneOfCaseInsensitiveValidator) Description(ctx context.Context) string 
 }
 
 func (v noneOfCaseInsensitiveValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("value must be none of: %q", v.values)
+	return fmt.Sprintf("value must be none of: %s", v.values)
 }
 
 func (v noneOfCaseInsensitiveValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {

--- a/stringvalidator/none_of_case_insensitive_test.go
+++ b/stringvalidator/none_of_case_insensitive_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 )
 
 func TestNoneOfCaseInsensitiveValidator(t *testing.T) {
@@ -89,6 +91,37 @@ func TestNoneOfCaseInsensitiveValidator(t *testing.T) {
 
 			if test.expErrors == 0 && res.Diagnostics.HasError() {
 				t.Fatalf("expected no error(s), got %d: %v", res.Diagnostics.ErrorsCount(), res.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestNoneOfCaseInsensitiveValidator_Description(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		in       []string
+		expected string
+	}
+
+	testCases := map[string]testCase{
+		"quoted-once": {
+			in:       []string{"foo", "bar", "baz"},
+			expected: `value must be none of: ["foo" "bar" "baz"]`,
+		},
+	}
+
+	for name, test := range testCases {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			v := stringvalidator.NoneOfCaseInsensitive(test.in...)
+
+			got := v.MarkdownDescription(context.Background())
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
 			}
 		})
 	}

--- a/stringvalidator/none_of_test.go
+++ b/stringvalidator/none_of_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -90,6 +91,37 @@ func TestNoneOfValidator(t *testing.T) {
 
 			if test.expErrors == 0 && res.Diagnostics.HasError() {
 				t.Fatalf("expected no error(s), got %d: %v", res.Diagnostics.ErrorsCount(), res.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestNoneOfValidator_Description(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		in       []string
+		expected string
+	}
+
+	testCases := map[string]testCase{
+		"quoted-once": {
+			in:       []string{"foo", "bar", "baz"},
+			expected: `value must be none of: ["foo" "bar" "baz"]`,
+		},
+	}
+
+	for name, test := range testCases {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			v := stringvalidator.NoneOf(test.in...)
+
+			got := v.MarkdownDescription(context.Background())
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
 			}
 		})
 	}

--- a/stringvalidator/one_of.go
+++ b/stringvalidator/one_of.go
@@ -25,7 +25,7 @@ func (v oneOfValidator) Description(ctx context.Context) string {
 }
 
 func (v oneOfValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("value must be one of: %q", v.values)
+	return fmt.Sprintf("value must be one of: %s", v.values)
 }
 
 func (v oneOfValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {

--- a/stringvalidator/one_of_case_insensitive.go
+++ b/stringvalidator/one_of_case_insensitive.go
@@ -26,7 +26,7 @@ func (v oneOfCaseInsensitiveValidator) Description(ctx context.Context) string {
 }
 
 func (v oneOfCaseInsensitiveValidator) MarkdownDescription(_ context.Context) string {
-	return fmt.Sprintf("value must be one of: %q", v.values)
+	return fmt.Sprintf("value must be one of: %s", v.values)
 }
 
 func (v oneOfCaseInsensitiveValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {

--- a/stringvalidator/one_of_case_insensitive_test.go
+++ b/stringvalidator/one_of_case_insensitive_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 )
 
 func TestOneOfCaseInsensitiveValidator(t *testing.T) {
@@ -89,6 +91,37 @@ func TestOneOfCaseInsensitiveValidator(t *testing.T) {
 
 			if test.expErrors == 0 && res.Diagnostics.HasError() {
 				t.Fatalf("expected no error(s), got %d: %v", res.Diagnostics.ErrorsCount(), res.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestOneOfCaseInsensitiveValidator_Description(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		in       []string
+		expected string
+	}
+
+	testCases := map[string]testCase{
+		"quoted-once": {
+			in:       []string{"foo", "bar", "baz"},
+			expected: `value must be one of: ["foo" "bar" "baz"]`,
+		},
+	}
+
+	for name, test := range testCases {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			v := stringvalidator.OneOfCaseInsensitive(test.in...)
+
+			got := v.MarkdownDescription(context.Background())
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
 			}
 		})
 	}

--- a/stringvalidator/one_of_test.go
+++ b/stringvalidator/one_of_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
@@ -90,6 +91,37 @@ func TestOneOfValidator(t *testing.T) {
 
 			if test.expErrors == 0 && res.Diagnostics.HasError() {
 				t.Fatalf("expected no error(s), got %d: %v", res.Diagnostics.ErrorsCount(), res.Diagnostics)
+			}
+		})
+	}
+}
+
+func TestOneOfValidator_Description(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		in       []string
+		expected string
+	}
+
+	testCases := map[string]testCase{
+		"quoted-once": {
+			in:       []string{"foo", "bar", "baz"},
+			expected: `value must be one of: ["foo" "bar" "baz"]`,
+		},
+	}
+
+	for name, test := range testCases {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			v := stringvalidator.OneOf(test.in...)
+
+			got := v.MarkdownDescription(context.Background())
+
+			if diff := cmp.Diff(got, test.expected); diff != "" {
+				t.Errorf("unexpected difference: %s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Closes: #149 

Usage of `fmt.Sprintf("......%q")` has been checked throughout and does not appear to be an issue except in the cases in the `stringvalidator` package that are fixed in this PR.