### PR TITLE
Minor fix to `stringvalidator.LengthBetween()`

### DIFF
--- a/stringvalidator/length_between.go
+++ b/stringvalidator/length_between.go
@@ -47,14 +47,14 @@ func (v lengthBetweenValidator) ValidateString(ctx context.Context, request vali
 	}
 }
 
-// LengthBetween returns an validator which ensures that any configured
-// attribute value is of single-byte character length greater than the given
-// minimum and less than the given maximum. Null (unconfigured) and unknown
-// (known after apply) values are skipped.
+// LengthBetween returns a validator which ensures that any configured
+// attribute value is of single-byte character length greater than or equal
+// to the given minimum and less than or equal to the given maximum. Null
+// (unconfigured) and unknown (known after apply) values are skipped.
 //
 // Use UTF8LengthBetween for checking multiple-byte characters.
 func LengthBetween(minLength, maxLength int) validator.String {
-	if minLength < 0 || maxLength < 0 || minLength > maxLength {
+	if minLength < 0 || minLength > maxLength {
 		return nil
 	}
 

--- a/stringvalidator/length_between_test.go
+++ b/stringvalidator/length_between_test.go
@@ -49,7 +49,7 @@ func TestLengthBetweenValidator(t *testing.T) {
 			minLength: 1,
 			maxLength: 2,
 		},
-		"valid just right": {
+		"valid minimum maximum equal": {
 			val:       types.StringValue("ok"),
 			minLength: 2,
 			maxLength: 2,

--- a/stringvalidator/length_between_test.go
+++ b/stringvalidator/length_between_test.go
@@ -54,7 +54,7 @@ func TestLengthBetweenValidator(t *testing.T) {
 			minLength: 2,
 			maxLength: 2,
 		},
-		"valid empty": {
+		"valid minimum maximum zero": {
 			val:       types.StringValue(""),
 			minLength: 0,
 			maxLength: 0,

--- a/stringvalidator/length_between_test.go
+++ b/stringvalidator/length_between_test.go
@@ -39,6 +39,26 @@ func TestLengthBetweenValidator(t *testing.T) {
 			minLength: 1,
 			maxLength: 3,
 		},
+		"valid minimum": {
+			val:       types.StringValue("ok"),
+			minLength: 2,
+			maxLength: 3,
+		},
+		"valid maximum": {
+			val:       types.StringValue("ok"),
+			minLength: 1,
+			maxLength: 2,
+		},
+		"valid just right": {
+			val:       types.StringValue("ok"),
+			minLength: 2,
+			maxLength: 2,
+		},
+		"valid empty": {
+			val:       types.StringValue(""),
+			minLength: 0,
+			maxLength: 0,
+		},
 		"too long": {
 			val:         types.StringValue("not ok"),
 			minLength:   1,


### PR DESCRIPTION
I wrote some bugs by relying on `LengthBetween()`'s Go doc comment.

The Go doc comment now more accurately reflects the validator behavior.

An unnecessary validation (max cannot be less than zero, even without this check) was removed.