### PR TITLE
feat: add json string validator

### DIFF
--- a/stringvalidator/json.go
+++ b/stringvalidator/json.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stringvalidator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.String = IsJsonValidator{}
+
+// IsJsonValidator validates that a string is valid Json.
+type IsJsonValidator struct{}
+
+// Description describes the validation in plain text formatting.
+func (validator IsJsonValidator) Description(_ context.Context) string {
+	return "string must be valid json"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator IsJsonValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// Takes a value containing JSON string and passes it through
+// the JSON parser to normalize it, returns either a parsing
+// error or normalized JSON string.
+func NormalizeJsonString(jsonString interface{}) (string, error) {
+	var j interface{}
+
+	if jsonString == nil || jsonString.(string) == "" {
+		return "", nil
+	}
+
+	s := jsonString.(string)
+
+	err := json.Unmarshal([]byte(s), &j)
+	if err != nil {
+		return s, err
+	}
+
+	bytes, _ := json.Marshal(j)
+	return string(bytes[:]), nil
+}
+
+// Validate performs the validation.
+func (v IsJsonValidator) ValidateString(ctx context.Context, request validator.StringRequest, response *validator.StringResponse) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueString()
+
+	if _, err := NormalizeJsonString(value); err != nil {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueLengthDiagnostic(
+			request.Path,
+			v.Description(ctx),
+			fmt.Sprintf("%s", v),
+		))
+
+		return
+	}
+}
+
+// IsJson returns an validator which validates string value is valid json
+func IsJson() validator.String {
+	return IsJsonValidator{}
+}

--- a/stringvalidator/json_test.go
+++ b/stringvalidator/json_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package stringvalidator_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+)
+
+func TestIsJsonValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val         types.String
+		expectError bool
+	}
+	tests := map[string]testCase{
+		"unknown": {
+			val: types.StringUnknown(),
+		},
+		"null": {
+			val: types.StringNull(),
+		},
+		"empty": {
+			val: types.StringValue(``),
+		},
+		"empty brackets": {
+			val: types.StringValue(`{}`),
+		},
+		"valid json": {
+			val: types.StringValue(`{"abc":["1","2"]}`),
+		},
+		"Invalid 1": {
+			val:         types.StringValue(`{0:"1"}`),
+			expectError: true,
+		},
+		"Invalid 2": {
+			val:         types.StringValue(`{'abc':1}`),
+			expectError: true,
+		},
+		"Invalid 3": {
+			val:         types.StringValue(`{"def":}`),
+			expectError: true,
+		},
+		"Invalid 4": {
+			val:         types.StringValue(`{"xyz":[}}`),
+			expectError: true,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.StringRequest{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    test.val,
+			}
+			response := validator.StringResponse{}
+			stringvalidator.IsJson().ValidateString(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding validator similar to [this func from sdk v2](https://github.com/hashicorp/terraform-plugin-sdk/blob/a4c5d29a735f3219632c2bd8290e80ebb5ed5c8c/helper/validation/strings.go#L212-L225) and it's [tests](https://github.com/hashicorp/terraform-plugin-sdk/blob/a4c5d29a735f3219632c2bd8290e80ebb5ed5c8c/helper/validation/strings_test.go#L379-L432) for validating a string is valid json. I'm not sure where to edit the changelog, so please let me know or feel free to edit this PR. 

## Testing
```zsh
╰─ go test -v -cover -timeout=120s -parallel=4 -run="TestIsJsonValidator" ./stringvalidator/json_test.go
=== RUN   TestIsJsonValidator
=== PAUSE TestIsJsonValidator
=== CONT  TestIsJsonValidator
=== RUN   TestIsJsonValidator/empty
=== PAUSE TestIsJsonValidator/empty
=== RUN   TestIsJsonValidator/empty_brackets
=== PAUSE TestIsJsonValidator/empty_brackets
=== RUN   TestIsJsonValidator/null
=== PAUSE TestIsJsonValidator/null
=== RUN   TestIsJsonValidator/valid_json
=== PAUSE TestIsJsonValidator/valid_json
=== RUN   TestIsJsonValidator/Invalid_1
=== PAUSE TestIsJsonValidator/Invalid_1
=== RUN   TestIsJsonValidator/Invalid_2
=== PAUSE TestIsJsonValidator/Invalid_2
=== RUN   TestIsJsonValidator/Invalid_3
=== PAUSE TestIsJsonValidator/Invalid_3
=== RUN   TestIsJsonValidator/Invalid_4
=== PAUSE TestIsJsonValidator/Invalid_4
=== RUN   TestIsJsonValidator/unknown
=== PAUSE TestIsJsonValidator/unknown
=== CONT  TestIsJsonValidator/empty
=== CONT  TestIsJsonValidator/Invalid_2
=== CONT  TestIsJsonValidator/empty_brackets
=== CONT  TestIsJsonValidator/null
=== CONT  TestIsJsonValidator/Invalid_4
=== CONT  TestIsJsonValidator/valid_json
=== CONT  TestIsJsonValidator/Invalid_3
=== CONT  TestIsJsonValidator/Invalid_1
=== CONT  TestIsJsonValidator/unknown
--- PASS: TestIsJsonValidator (0.00s)
    --- PASS: TestIsJsonValidator/empty (0.00s)
    --- PASS: TestIsJsonValidator/null (0.00s)
    --- PASS: TestIsJsonValidator/Invalid_4 (0.00s)
    --- PASS: TestIsJsonValidator/Invalid_2 (0.00s)
    --- PASS: TestIsJsonValidator/Invalid_3 (0.00s)
    --- PASS: TestIsJsonValidator/Invalid_1 (0.00s)
    --- PASS: TestIsJsonValidator/empty_brackets (0.00s)
    --- PASS: TestIsJsonValidator/unknown (0.00s)
    --- PASS: TestIsJsonValidator/valid_json (0.00s)
PASS
coverage: [no statements]
ok      command-line-arguments  0.137s  coverage: [no statements]

```
