### PR TITLE
Add `AtMostDecimalDigits` validator for float64 attribute precision validation

### DIFF
--- a/float64validator/at_most_decimal_digits.go
+++ b/float64validator/at_most_decimal_digits.go
@@ -1,0 +1,74 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package float64validator
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+var _ validator.Float64 = atMostDecimalDigitsValidator{}
+
+// atMostDecimalDigitsValidator validates that an float Attribute's value has at most a certain number of decimal digits.
+type atMostDecimalDigitsValidator struct {
+	atMostDecimalDigits int
+}
+
+// Description describes the validation in plain text formatting.
+func (validator atMostDecimalDigitsValidator) Description(_ context.Context) string {
+	return fmt.Sprintf("value must have up to %d decimal digits", validator.atMostDecimalDigits)
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (validator atMostDecimalDigitsValidator) MarkdownDescription(ctx context.Context) string {
+	return validator.Description(ctx)
+}
+
+// ValidateFloat64 performs the validation.
+func (validator atMostDecimalDigitsValidator) ValidateFloat64(ctx context.Context, request validator.Float64Request, response *validator.Float64Response) {
+	if request.ConfigValue.IsNull() || request.ConfigValue.IsUnknown() {
+		return
+	}
+
+	value := request.ConfigValue.ValueFloat64()
+
+	if decDigits := countDecimalDigits(value); decDigits > validator.atMostDecimalDigits {
+		response.Diagnostics.Append(validatordiag.InvalidAttributeValueDiagnostic(
+			request.Path,
+			validator.Description(ctx),
+			strconv.Itoa(decDigits),
+		))
+	}
+}
+
+// countDecimalDigits returns the number of decimal digits in a float64.
+func countDecimalDigits(f float64) int {
+	str := strconv.FormatFloat(f, 'f', -1, 64)
+	str = strings.TrimRight(str, "0")
+	parts := strings.Split(str, ".")
+	if len(parts) != 2 {
+		return 0
+	}
+	return len(parts[1])
+}
+
+// AtMostDecimalDigits returns an AttributeValidator which ensures that any configured
+// attribute value:
+//
+//   - It contains less than or equal to the given maximum number of decimal digits.
+//
+// Null (unconfigured) and unknown (known after apply) values are skipped.
+func AtMostDecimalDigits(atMostDecimalDigits int) validator.Float64 {
+	if atMostDecimalDigits < 0 {
+		return nil
+	}
+	return atMostDecimalDigitsValidator{
+		atMostDecimalDigits: atMostDecimalDigits,
+	}
+}

--- a/float64validator/at_most_decimal_digits_example_test.go
+++ b/float64validator/at_most_decimal_digits_example_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package float64validator_test
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+func ExampleAtMostDecimalDigits() {
+	// Used within a Schema method of a DataSource, Provider, or Resource
+	_ = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"example_attr": schema.Float64Attribute{
+				Required: true,
+				Validators: []validator.Float64{
+					// Validate floating point value must have precision upto 5 decimal digits
+					float64validator.AtMostDecimalDigits(5),
+				},
+			},
+		},
+	}
+}

--- a/float64validator/at_most_decimal_digits_test.go
+++ b/float64validator/at_most_decimal_digits_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package float64validator_test
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+)
+
+func TestAtMostDecimalDigitsValidator(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		val                 types.Float64
+		atMostDecimalDigits int
+		expectError         bool
+	}
+	tests := map[string]testCase{
+		"unknown Float64": {
+			val:                 types.Float64Unknown(),
+			atMostDecimalDigits: 1,
+		},
+		"null Float64": {
+			val:                 types.Float64Null(),
+			atMostDecimalDigits: 2,
+		},
+		"valid integer as Float64": {
+			val:                 types.Float64Value(1),
+			atMostDecimalDigits: 2,
+		},
+		"valid float as Float64": {
+			val:                 types.Float64Value(1.1),
+			atMostDecimalDigits: 2,
+		},
+		"valid float as Float64 max": {
+			val:                 types.Float64Value(2.0),
+			atMostDecimalDigits: 2,
+		},
+		"too large float as Float64": {
+			val:                 types.Float64Value(math.MaxFloat64),
+			atMostDecimalDigits: 2,
+		},
+		"zero decimal digits": {
+			val:                 types.Float64Value(3.0000),
+			atMostDecimalDigits: 2,
+		},
+		"more than allowed decimal digits": {
+			val:                 types.Float64Value(3.00099),
+			atMostDecimalDigits: 3,
+			expectError:         true,
+		},
+		"exactly same as allowed decimal digits": {
+			val:                 types.Float64Value(54545.009),
+			atMostDecimalDigits: 3,
+		},
+		"less than allowed decimal digits": {
+			val:                 types.Float64Value(0.09),
+			atMostDecimalDigits: 3,
+		},
+	}
+
+	for name, test := range tests {
+		name, test := name, test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			request := validator.Float64Request{
+				Path:           path.Root("test"),
+				PathExpression: path.MatchRoot("test"),
+				ConfigValue:    test.val,
+			}
+			response := validator.Float64Response{}
+			float64validator.AtMostDecimalDigits(test.atMostDecimalDigits).ValidateFloat64(context.TODO(), request, &response)
+
+			if !response.Diagnostics.HasError() && test.expectError {
+				t.Fatal("expected error, got no error")
+			}
+
+			if response.Diagnostics.HasError() && !test.expectError {
+				t.Fatalf("got unexpected error: %s", response.Diagnostics)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

This pull request introduces a new validator, AtMostDecimalDigits, to validate float attributes in Terraform providers. The `AtMostDecimalDigits` validator ensures that a float attribute's value has at most a specified number of decimal digits. This is particularly useful for enforcing precision requirements in floating-point values.

## Usage

The AtMostDecimalDigits validator can be used within the Schema method of a DataSource, Provider, or Resource as follows:

```go
_ = schema.Schema{
    Attributes: map[string]schema.Attribute{
        "example_attr": schema.Float64Attribute{
            Required: true,
            Validators: []validator.Float64{
                // Validate floating point value must have precision up to 5 decimal digits
                float64validator.AtMostDecimalDigits(5),
            },
        },
    },
}
```

This example demonstrates using the AtMostDecimalDigits validator to enforce a precision requirement of up to 5 decimal digits for the "example_attr" attribute. For example `3.0, 23.00025, 3.99999, 0.000010` are valid but `0.25666698` is invalid.

### Implementation Details
The implementation of the `AtMostDecimalDigits` validator includes logic to check the number of decimal digits in a float attribute's value and ensure that it does not exceed the specified limit.