### PR TITLE
internal/schemavalidator: Fix bug where unknown values were returning error diagnostics too early

### DIFF
--- a/.changes/unreleased/BUG FIXES-20241212-152125.yaml
+++ b/.changes/unreleased/BUG FIXES-20241212-152125.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fixed bug with `ConflictsWith` and `AlsoRequires` validators where unknown values
+  would raise invalid diagnostics during `terraform validate`.
+time: 2024-12-12T15:21:25.964001-05:00
+custom:
+  Issue: "251"

--- a/internal/schemavalidator/also_requires.go
+++ b/internal/schemavalidator/also_requires.go
@@ -58,7 +58,8 @@ func (av AlsoRequiresValidator) MarkdownDescription(_ context.Context) string {
 
 func (av AlsoRequiresValidator) Validate(ctx context.Context, req AlsoRequiresValidatorRequest, res *AlsoRequiresValidatorResponse) {
 	// If attribute configuration is null, there is nothing else to validate
-	if req.ConfigValue.IsNull() {
+	// If attribute configuration is unknown, delay the validation until it is known.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
 

--- a/internal/schemavalidator/also_requires_test.go
+++ b/internal/schemavalidator/also_requires_test.go
@@ -80,6 +80,33 @@ func TestAlsoRequiresValidatorValidate(t *testing.T) {
 				path.MatchRoot("foo"),
 			},
 		},
+		"self-is-unknown": {
+			req: schemavalidator.AlsoRequiresValidatorRequest{
+				ConfigValue:    types.StringUnknown(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, nil),
+						"bar": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					}),
+				},
+			},
+			in: path.Expressions{
+				path.MatchRoot("foo"),
+			},
+		},
 		"error_missing-one": {
 			req: schemavalidator.AlsoRequiresValidatorRequest{
 				ConfigValue:    types.StringValue("bar value"),

--- a/internal/schemavalidator/at_least_one_of.go
+++ b/internal/schemavalidator/at_least_one_of.go
@@ -58,6 +58,7 @@ func (av AtLeastOneOfValidator) MarkdownDescription(_ context.Context) string {
 
 func (av AtLeastOneOfValidator) Validate(ctx context.Context, req AtLeastOneOfValidatorRequest, res *AtLeastOneOfValidatorResponse) {
 	// If attribute configuration is not null, validator already succeeded.
+	// If attribute configuration is unknown, delay the validation until it is known.
 	if !req.ConfigValue.IsNull() {
 		return
 	}

--- a/internal/schemavalidator/at_least_one_of_test.go
+++ b/internal/schemavalidator/at_least_one_of_test.go
@@ -84,6 +84,34 @@ func TestAtLeastOneOfValidatorValidate(t *testing.T) {
 			},
 			expected: &schemavalidator.AtLeastOneOfValidatorResponse{},
 		},
+		"self-is-unknown": {
+			req: schemavalidator.AtLeastOneOfValidatorRequest{
+				ConfigValue:    types.StringUnknown(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, 42),
+						"bar": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					}),
+				},
+			},
+			in: path.Expressions{
+				path.MatchRoot("foo"),
+			},
+			expected: &schemavalidator.AtLeastOneOfValidatorResponse{},
+		},
 		"error_none-set": {
 			req: schemavalidator.AtLeastOneOfValidatorRequest{
 				ConfigValue:    types.StringNull(),

--- a/internal/schemavalidator/conflicts_with.go
+++ b/internal/schemavalidator/conflicts_with.go
@@ -58,7 +58,8 @@ func (av ConflictsWithValidator) MarkdownDescription(_ context.Context) string {
 
 func (av ConflictsWithValidator) Validate(ctx context.Context, req ConflictsWithValidatorRequest, res *ConflictsWithValidatorResponse) {
 	// If attribute configuration is null, it cannot conflict with others
-	if req.ConfigValue.IsNull() {
+	// If attribute configuration is unknown, delay the validation until it is known.
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
 		return
 	}
 

--- a/internal/schemavalidator/conflicts_with_test.go
+++ b/internal/schemavalidator/conflicts_with_test.go
@@ -139,6 +139,33 @@ func TestConflictsWithValidatorValidate(t *testing.T) {
 				path.MatchRoot("foo"),
 			},
 		},
+		"self-is-unknown": {
+			req: schemavalidator.ConflictsWithValidatorRequest{
+				ConfigValue:    types.StringUnknown(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, 42),
+						"bar": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					}),
+				},
+			},
+			in: path.Expressions{
+				path.MatchRoot("foo"),
+			},
+		},
 		"error_allow-duplicate-input": {
 			req: schemavalidator.ConflictsWithValidatorRequest{
 				ConfigValue:    types.StringValue("bar value"),

--- a/internal/schemavalidator/exactly_one_of_test.go
+++ b/internal/schemavalidator/exactly_one_of_test.go
@@ -81,6 +81,33 @@ func TestExactlyOneOfValidator(t *testing.T) {
 				path.MatchRoot("foo"),
 			},
 		},
+		"self-is-unknown": {
+			req: schemavalidator.ExactlyOneOfValidatorRequest{
+				ConfigValue:    types.StringUnknown(),
+				Path:           path.Root("bar"),
+				PathExpression: path.MatchRoot("bar"),
+				Config: tfsdk.Config{
+					Schema: schema.Schema{
+						Attributes: map[string]schema.Attribute{
+							"foo": schema.Int64Attribute{},
+							"bar": schema.StringAttribute{},
+						},
+					},
+					Raw: tftypes.NewValue(tftypes.Object{
+						AttributeTypes: map[string]tftypes.Type{
+							"foo": tftypes.Number,
+							"bar": tftypes.String,
+						},
+					}, map[string]tftypes.Value{
+						"foo": tftypes.NewValue(tftypes.Number, 42),
+						"bar": tftypes.NewValue(tftypes.String, tftypes.UnknownValue),
+					}),
+				},
+			},
+			in: path.Expressions{
+				path.MatchRoot("foo"),
+			},
+		},
 		"error_too-many": {
 			req: schemavalidator.ExactlyOneOfValidatorRequest{
 				ConfigValue:    types.StringValue("bar value"),


### PR DESCRIPTION
Closes #251 

This PR introduces a small fix to the `internal/schemavalidator` package (used by all of the type specific equivalents), where unknown values were being treated as if they were known "not null" values, thus raising early diagnostics where they may not be valid (see linked issue).

This fix was made to `ConflictsWith` and `AlsoRequires`, but I also added tests to the other already working schema validators. Eventually when #250 lands, we can update these validators to check for the "not null refinement", to reintroduce earlier diagnostics accurately for unknown values.

Test errors prior to fix:
```bash
--- FAIL: TestConflictsWithValidatorValidate (0.00s)
--- FAIL: TestConflictsWithValidatorValidate/self-is-unknown (0.00s)

/Users/austin.valle/code/terraform-plugin-framework-validators/internal/schemavalidator/conflicts_with_test.go:287: expected no error(s), got 1: [{{Attribute "foo" cannot be specified when "bar" is specified Invalid Attribute Combination} {[bar]}}]
```

```bash
--- FAIL: TestAlsoRequiresValidatorValidate (0.00s)
--- FAIL: TestAlsoRequiresValidatorValidate/self-is-unknown (0.00s)

/Users/austin.valle/code/terraform-plugin-framework-validators/internal/schemavalidator/also_requires_test.go:286: expected no error(s), got 1: [{{Attribute "foo" must be specified when "bar" is specified Invalid Attribute Combination} {[bar]}}]
```
