### PR TITLE
Add Callout for `PreferWriteOnlyAttribute()` validators in GoDoc comments

### DIFF
--- a/.changes/0.17.0.md
+++ b/.changes/0.17.0.md
@@ -13,6 +13,5 @@ FEATURES:
 * numbervalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
 * objectvalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
 * resourcevalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
-* setvalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
 * stringvalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ FEATURES:
 * numbervalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
 * objectvalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
 * resourcevalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
-* setvalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
 * stringvalidator: Added `PreferWriteOnlyAttribute` validator ([#263](https://github.com/hashicorp/terraform-plugin-framework-validators/issues/263))
 
 ## 0.16.0 (December 12, 2024)

--- a/boolvalidator/prefer_write_only_attribute.go
+++ b/boolvalidator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Bool {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/dynamicvalidator/prefer_write_only_attribute.go
+++ b/dynamicvalidator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Dynamic {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/float32validator/prefer_write_only_attribute.go
+++ b/float32validator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Float32 {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/float64validator/prefer_write_only_attribute.go
+++ b/float64validator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Float64 {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/int32validator/prefer_write_only_attribute.go
+++ b/int32validator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Int32 {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/int64validator/prefer_write_only_attribute.go
+++ b/int64validator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Int64 {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/listvalidator/prefer_write_only_attribute.go
+++ b/listvalidator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.List {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/mapvalidator/prefer_write_only_attribute.go
+++ b/mapvalidator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Map {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/numbervalidator/prefer_write_only_attribute.go
+++ b/numbervalidator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Number {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/objectvalidator/prefer_write_only_attribute.go
+++ b/objectvalidator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.Object {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,

--- a/resourcevalidator/prefer_write_only_attribute.go
+++ b/resourcevalidator/prefer_write_only_attribute.go
@@ -14,6 +14,9 @@ import (
 
 // PreferWriteOnlyAttribute returns a warning if the Terraform client supports
 // write-only attributes, and the old attribute value is not null.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(oldAttribute path.Expression, writeOnlyAttribute path.Expression) resource.ConfigValidator {
 	return preferWriteOnlyAttributeValidator{
 		oldAttribute:       oldAttribute,

--- a/stringvalidator/prefer_write_only_attribute.go
+++ b/stringvalidator/prefer_write_only_attribute.go
@@ -21,6 +21,9 @@ import (
 // This implements the validation logic declaratively within the schema.
 // Refer to [resourcevalidator.PreferWriteOnlyAttribute]
 // for declaring this type of validation outside the schema definition.
+//
+// NOTE: This validator will produce persistent warnings for practitioners on every Terraform run as long as the specified non-write-only attribute
+// has a value in the configuration. The validator will also produce warnings for users of shared modules who cannot immediately take action on the warning.
 func PreferWriteOnlyAttribute(writeOnlyAttribute path.Expression) validator.String {
 	return schemavalidator.PreferWriteOnlyAttribute{
 		WriteOnlyAttribute: writeOnlyAttribute,


### PR DESCRIPTION
Adds a callout for `PreferWriteOnlyAttribute()` validators usage about the persistent nature of the warnings for practitioners.